### PR TITLE
Use vapply instead of sapply

### DIFF
--- a/R/zeroPad.r
+++ b/R/zeroPad.r
@@ -16,7 +16,11 @@ zeroPad <- function(x,padTo){
   if(padTo <= 1) return(x)
   numDigits <- nchar(x)
   padding <- padTo-numDigits
-  padingZeros <- sapply(padding[padding > 0], function(y) paste(rep("0",y),collapse="",sep=""))
+  padingZeros <- vapply(
+      X = padding[padding > 0], 
+      FUN = function(y) paste(rep("0",y),collapse="",sep=""),
+      FUN.VALUE = ""
+  )
   x[padding > 0] <- paste(padingZeros,x[padding > 0],sep="")
   return(x)
 }


### PR DESCRIPTION
At least one major R contributor - Hadley Wickham - has advised against using sapply in functions. Instead he advocates lapply or vapply. 

See
https://twitter.com/hadleywickham/status/434339083871993856
http://stackoverflow.com/questions/12339650/why-is-vapply-safer-than-sapply