### PR TITLE
fix ML2 parsing, NA removal in ML1

### DIFF
--- a/R/importNGWMN_wml2.R
+++ b/R/importNGWMN_wml2.R
@@ -161,9 +161,9 @@ importWaterML2 <- function(input, asDateTime=FALSE, tz="UTC") {
                       time = character(0), dateTime = character(0), value = numeric(0),
                       uom = character(0), comment = character(0), stringsAsFactors = FALSE))
   }
-  rawTime <- xml_text(xml_find_all(TVP,".//wml2:time"))
+  rawTime <- xml_text(xml_find_all(returnedDoc, "./wml2:point/wml2:MeasurementTVP/wml2:time"))
   
-  valueNodes <- xml_find_all(TVP,".//wml2:value")
+  valueNodes <- xml_find_all(returnedDoc,"./wml2:point/wml2:MeasurementTVP/wml2:value")
   values <- as.numeric(xml_text(valueNodes))
   nVals <- length(values)
   
@@ -192,9 +192,13 @@ importWaterML2 <- function(input, asDateTime=FALSE, tz="UTC") {
   
   uom <- xml_attr(valueNodes, "uom", default = NA)
   
-  source <- xml_attr(xml_find_all(TVP, ".//wml2:source"), "title")
-  comment <- xml_text(xml_find_all(TVP, ".//wml2:comment"))
-  tvpQuals <- xml_text(xml_find_all(TVP, ".//swe:description"))
+  source <- xml_attr(xml_find_all(returnedDoc, 
+                                  "./wml2:point/wml2:MeasurementTVP/wml2:metadata/wml2:source"), 
+                     "title")
+  comment <- xml_text(xml_find_all(returnedDoc, 
+                  "./wml2:point/wml2:MeasurementTVP/wml2:metadata/wml2:comment"))
+  tvpQuals <- xml_text(xml_find_all(returnedDoc, 
+                        "./wml2:point/wml2:MeasurementTVP/wml2:metadata/swe:description"))
   defaultMeta <- xml_find_all(returnedDoc, ".//wml2:DefaultTVPMeasurementMetadata")
   defaultQuals <- xml_text(xml_find_all(defaultMeta, ".//swe:description"))
   defaultUOM <- xml_attr(xml_find_all(defaultMeta, ".//wml2:uom"), "title", default = NA)

--- a/R/importWaterML1.r
+++ b/R/importWaterML1.r
@@ -268,7 +268,7 @@ importWaterML1 <- function(obs_url,asDateTime=FALSE, tz="UTC"){
     
     #replace no data vals with NA, change attribute df
     noDataVal <- as.numeric(varText$noDataValue)
-    if(nObs > 0 & obsColName %in% names(nObs)){
+    if(nObs > 0 & obsColName %in% names(obsDF)){
       obsDF[[obsColName]][obsDF[[obsColName]] == noDataVal] <- NA
     }
     varText$noDataValue <- NA

--- a/R/importWaterML1.r
+++ b/R/importWaterML1.r
@@ -346,7 +346,7 @@ check_if_xml <- function(obs_url){
     returnedDoc <- read_xml(obs_url)
   }else if(class(obs_url) == 'raw'){
     returnedDoc <- read_xml(obs_url)
-  } else if(class(obs_url) == "xml_node"){
+  } else if(inherits(obs_url, c("xml_node", "xml_nodeset"))) {
     returnedDoc <- obs_url
   } else {
     returnedDoc <- xml_root(getWebServiceData(obs_url, encoding='gzip'))

--- a/tests/testthat/tests_general.R
+++ b/tests/testthat/tests_general.R
@@ -6,7 +6,6 @@ test_that("General NWIS retrievals working", {
   multiSite <- readNWISdata(sites=c("04025500","040263491"), service="iv", 
                             parameterCd="00060")
   expect_is(multiSite$dateTime, 'POSIXct')
-  # saveRDS(multiSite, "rds/multiSite.rds")
   
   recent_uv <- readNWISdata(siteNumber="04025500",parameterCd="00060",service="uv",
                           startDate=as.Date(Sys.Date()-10),endDate=Sys.Date())
@@ -22,25 +21,21 @@ test_that("General NWIS retrievals working", {
   
   bBoxEx <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010")
   expect_that(length(unique(bBoxEx$site_no)) > 1, is_true())
-  # saveRDS(bBoxEx, "rds/bBoxEx.rds")
   
   startDate <- as.Date("2013-10-01")
   endDate <- as.Date("2014-09-30")
   waterYear <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010", 
                    service="dv", startDate=startDate, endDate=endDate)
-  # saveRDS(waterYear, "rds/waterYear.rds")
   expect_is(waterYear$dateTime, 'POSIXct')
   
   siteInfo <- readNWISdata(stateCd="WI", parameterCd="00010",hasDataTypeCd="iv", 
                            service="site")
-  # saveRDS(siteInfo,"rds/siteInfo.rds")
   expect_is(siteInfo$station_nm, "character")
   
   qwData <- readNWISdata(bBox=c(-82.5,41.52,-81,41),startDate=as.Date("2000-01-01"),
                    drain_area_va_min=50, qw_count_nu=50,qw_attributes="expanded",
                     qw_sample_wide="wide",list_of_search_criteria=c("lat_long_bounding_box",
                     "drain_area_va","obs_count_nu"),service="qw")
-  # saveRDS(qwData, "rds/qwData.rds")
   expect_is(qwData$startDateTime, "POSIXct")
   
   url <- "https://waterservices.usgs.gov/nwis/dv/?site=09037500&format=rdb&ParameterCd=00060&StatCd=00003&startDT=1985-10-02&endDT=2012-09-06"
@@ -48,18 +43,15 @@ test_that("General NWIS retrievals working", {
   
   urlEmpty <- "https://nwis.waterdata.usgs.gov/nwis/qwdata?multiple_site_no=413437087150601&sort_key=site_no&group_key=NONE&inventory_output=0&begin_date=&end_date=&TZoutput=0&param_group=NUT,INN&qw_attributes=0&format=rdb&qw_sample_wide=0&rdb_qw_attributes=expanded&date_format=YYYY-MM-DD&rdb_compression=value&list_of_search_criteria=multiple_site_no"
   dv <- importRDB1(urlEmpty, asDateTime = FALSE)
-  # saveRDS(dv, "rds/emptyDV.rds")
   expect_that(nrow(dv) == 0, is_true())
   
   dailyStat <- readNWISdata(site=c("03112500","03111520"),service="stat",statReportType="daily",
                            statType=c("p25","p50","p75","min","max"),parameterCd="00065",convertType=FALSE)
-  # saveRDS(dailyStat,"rds/dailyStat.rds")
   expect_that(length(dailyStat$min_va) > 1, is_true())
   expect_is(dailyStat$p25_va,"character")
   
   waterYearStat <- readNWISdata(site=c("03112500"),service="stat",statReportType="annual",
                                 statYearType="water", missingData="on")
-  # saveRDS(waterYearStat, "rds/waterYearStat.rds")
   expect_is(waterYearStat$mean_va,"numeric")
   expect_is(waterYearStat$parameter_cd,"character")
   

--- a/tests/testthat/tests_general.R
+++ b/tests/testthat/tests_general.R
@@ -352,7 +352,7 @@ test_that("NGWMN functions working", {
   expect_is(tzDataUTC$dateTime, "POSIXct")
   expect_is(tzDataMT$dateTime, "POSIXct")
   expect_equal(attr(tzDataMT$dateTime, 'tzone'), "US/Mountain")
-  expect_warning(tzDataUTC$dateTime == tzDataMT$dateTime)
+  expect_equal(attr(tzDataUTC$dateTime, 'tzone'), "UTC")
 })
 
 context("getWebServiceData")

--- a/tests/testthat/tests_imports.R
+++ b/tests/testthat/tests_imports.R
@@ -75,7 +75,6 @@ test_that("CRAN-friendly importWaterML1 test", {
   fileName <- "WaterML1Example.xml"
   fullPath <- file.path(filePath, fileName)
   importUserWML1 <- importWaterML1(fullPath, asDateTime = TRUE)
-  # saveRDS(importUserWML1, "rds/importUserWML1.rds")
   # default is to turn dates to characters
   expect_is(importUserWML1$dateTime, 'POSIXct')
   
@@ -92,7 +91,6 @@ test_that("External importWaterML1 test", {
   obs_url <- constructNWISURL(siteNumber,property,startDate,endDate,'dv')
 
   data <- importWaterML1(obs_url,TRUE)
-  # saveRDS(data, "rds/dvWML1.rds")
   expect_is(data$dateTime, 'POSIXct')
 
   groundWaterSite <- "431049071324301"
@@ -101,7 +99,6 @@ test_that("External importWaterML1 test", {
   groundwaterExampleURL <- constructNWISURL(groundWaterSite, NA,
            startGW,endGW, service="gwlevels")
   groundWater <- importWaterML1(groundwaterExampleURL)
-  # saveRDS(groundWater, "rds/groundwater.rds")
 
   expect_is(groundWater$dateTime, 'character')
 
@@ -128,7 +125,6 @@ test_that("External importWaterML1 test", {
   inactiveAndActive <- constructNWISURL(inactiveAndActive, "00060", 
                                         "2014-01-01", "2014-12-31",'dv')
   inactiveAndActive <- importWaterML1(inactiveAndActive)
-  # saveRDS(inactiveAndActive, "rds/inactiveAndActive.rds")
   # 
   expect_true(length(unique(inactiveAndActive$site_no)) < 2)
   

--- a/tests/testthat/tests_imports.R
+++ b/tests/testthat/tests_imports.R
@@ -112,7 +112,6 @@ test_that("External importWaterML1 test", {
   obs_url <- constructNWISURL(siteNumber,c("00060","00010"),startDate,endDate,'dv')
   data <- importWaterML1(obs_url)
   
-  expect_false(any(data$X_00010_00003) )
   expect_that(length(unique(data$site_no)) == 2, is_true())
   expect_that(ncol(data) == 8, is_true()) # 3 data, 3 remark codes, and 4 (agency, site, dateTime, tz)
 

--- a/tests/testthat/tests_imports.R
+++ b/tests/testthat/tests_imports.R
@@ -180,9 +180,9 @@ context("importWaterML2")
 test_that("importWaterML2 internal test", {
   filePath <- system.file("extdata", package="dataRetrieval")
   fileName <- "WaterML2Example.xml"
-  fullPath <- file.path(filePath, fileName)
-  UserData <- importWaterML2(fullPath)
-  # saveRDS(UserData, "rds/UserData.rds")
+  xml_full <- xml2::read_xml(file.path(filePath, fileName))
+  measurementTS <- xml2::xml_find_all(xml_full, "//wml2:MeasurementTimeseries")
+  UserData <- importWaterML2(measurementTS)
   expect_is(UserData$value, 'numeric')
   # expect_is(UserData$qualifier, 'character')
   
@@ -191,8 +191,9 @@ test_that("importWaterML2 internal test", {
 test_that("importWaterML2 external test", {
   testthat::skip_on_cran()
   url <- "https://waterservices.usgs.gov/nwis/iv/?format=waterml,2.0&sites=01646500&parameterCd=00060,00065"
-  exData <- importWaterML2(url)
-  # saveRDS(data, "rds/externalML2.rds")
+  xml <- getWebServiceData(url)
+  measurementTS2 <- xml2::xml_find_all(xml, "//wml2:MeasurementTimeseries")
+  exData <- importWaterML2(measurementTS2)
   expect_is(exData$value, 'numeric')
   expect_gt(nrow(exData),0)
 })


### PR DESCRIPTION
Apparently the NGWMN functions were hanging due to the parser, not the web service... now fixed.  Still a bit confused about some of the behavior of `xml2::read_xml` when given a nodeset vs a node with children.

also fixes #392 