### PR TITLE
addressing errors in readNWISstat

### DIFF
--- a/R/readNWISunit.r
+++ b/R/readNWISunit.r
@@ -503,7 +503,12 @@ readNWISstat <- function(siteNumbers, parameterCd, startDate = "", endDate = "",
   data <- importRDB1(url,asDateTime=TRUE, convertType = convertType)
   
   siteInfo <- readNWISsite(siteNumbers)
-  siteInfo <- left_join(unique(data[,c("agency_cd","site_no")]),siteInfo, by=c("agency_cd","site_no"))
+  
+  if(nrow(data) > 0){
+    siteInfo <- left_join(unique(data[,c("agency_cd","site_no")]),siteInfo, by=c("agency_cd","site_no"))
+    warning("Empty dataset.")
+  }
+  
   attr(data, "siteInfo") <- siteInfo
   
   return (data)

--- a/R/readNWISunit.r
+++ b/R/readNWISunit.r
@@ -506,7 +506,6 @@ readNWISstat <- function(siteNumbers, parameterCd, startDate = "", endDate = "",
   
   if(nrow(data) > 0){
     siteInfo <- left_join(unique(data[,c("agency_cd","site_no")]),siteInfo, by=c("agency_cd","site_no"))
-    warning("Empty dataset.")
   }
   
   attr(data, "siteInfo") <- siteInfo


### PR DESCRIPTION
This line may resolve issue #428 (readNWISstat failing on empty returns)

It also resolves a similar error I had:
readNWISstat(siteNumbers = '02108000',
              parameterCd = "00600",
              startDate = "1800-01",
              endDate = format(Sys.time(), "%Y-%m"),
              statReportType="monthly",
              statType="mean")

This addition makes sure data is available to join before performing the left_join operation.  