### PR TITLE
fancier Count column identification

### DIFF
--- a/R/whatWQPdata.R
+++ b/R/whatWQPdata.R
@@ -133,7 +133,7 @@ whatWQPdata <- function(..., saveFile = tempfile()){
     y <- bind_cols(y, retval[[i]])
   }
   
-  y[,grep("Count",names(y))] <- sapply(y[,grep("Count",names(y))], as.numeric)
+  y[,grep("Count$",names(y))] <- sapply(y[,grep("Count$",names(y))], as.numeric)
   
   names(y)[names(y) == "type"] <- paste("type",letters[1:length(names(y)[names(y) == "type"])],sep="_")
   


### PR DESCRIPTION
Fixes #435. Running the same query given in that issue, I can now get non-NA CountyNames:
```r
             type_a features.type type1         coordinates ProviderName OrganizationIdentifier
1 FeatureCollection       Feature Point -93.03556, 45.08222         NWIS                USGS-MN
2 FeatureCollection       Feature Point -93.04310, 45.08197       STORET                  MNPCA
3 FeatureCollection       Feature Point -93.04060, 45.08359       STORET                  MNPCA
                                      OrganizationFormalName MonitoringLocationIdentifier
1                        USGS Minnesota Water Science Center         USGS-450456093020801
2 Minnesota Pollution Control Agency - Ambient Surface Water         MNPCA-62-0024-00-202
3 Minnesota Pollution Control Agency - Ambient Surface Water         MNPCA-62-0024-00-401
                              MonitoringLocationName   MonitoringLocationTypeName
1 BIRCH LAKE, SOUTHEAST SIDE, IN WHITE BEAR LAKE, MN Lake, Reservoir, Impoundment
2                                              BIRCH                         Lake
3                                              BIRCH                         Lake
  ResolvedMonitoringLocationTypeName HUCEightDigitCode
1       Lake, Reservoir, Impoundment          07010206
2       Lake, Reservoir, Impoundment          07010206
3       Lake, Reservoir, Impoundment          07010206
                                                                      siteUrl activityCount
1 https://www.waterqualitydata.us/provider/NWIS/USGS-MN/USGS-450456093020801/             1
2 https://www.waterqualitydata.us/provider/STORET/MNPCA/MNPCA-62-0024-00-202/            89
3 https://www.waterqualitydata.us/provider/STORET/MNPCA/MNPCA-62-0024-00-401/            44
  resultCount StateName                   CountyName
1           1 Minnesota US, Minnesota, Ramsey County
2          89 Minnesota US, Minnesota, Ramsey County
3          44 Minnesota US, Minnesota, Ramsey County
```