### PR TITLE
Hyperlink DOI to preferred resolver

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -12,5 +12,5 @@ bibentry(bibtype = "InBook",
   year = 2015,
   chapter = "A10",
   url = "https://pubs.usgs.gov/tm/04/a10/",
-  textVersion = "Hirsch, R.M., and De Cicco, L.A., 2015, User guide to Exploration and Graphics for RivEr Trends (EGRET) and dataRetrieval: R packages for hydrologic data (version 2.0, February 2015): U.S. Geological Survey Techniques and Methods book 4, chap. A10, 93 p., http://dx.doi.org/10.3133/tm4A10"
+  textVersion = "Hirsch, R.M., and De Cicco, L.A., 2015, User guide to Exploration and Graphics for RivEr Trends (EGRET) and dataRetrieval: R packages for hydrologic data (version 2.0, February 2015): U.S. Geological Survey Techniques and Methods book 4, chap. A10, 93 p., https://doi.org/10.3133/tm4A10"
 )


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all your static DOI links.

Cheers!