### PR TITLE
force activityendtime timezone code to character, #447

### DIFF
--- a/R/importWQP.R
+++ b/R/importWQP.R
@@ -98,7 +98,8 @@ importWQP <- function(obs_url, zip=FALSE, tz="UTC"){
                                         ResultMeasureValue = col_number(),
                                         `WellDepthMeasure/MeasureValue` = col_number(),
                                         `WellHoleDepthMeasure/MeasureValue` = col_number(),
-                                        `HUCEightDigitCode` = col_character()),
+                                        `HUCEightDigitCode` = col_character(), 
+                                        `ActivityEndTime/TimeZoneCode` = col_character()),
                        quote = "", delim = "\t"))
     
   if(!file.exists(obs_url)){


### PR DESCRIPTION
This PR solves #447 by forcing missing activityendtime timezone code fields to be read as character. I suspect that casting more fields to character would be a good idea to account for them being read as logical because they are completely `NA`.