### PR TITLE
quiet requireNamespace check and move web service call into findNLDI

### DIFF
--- a/R/AAA.R
+++ b/R/AAA.R
@@ -3,6 +3,5 @@ pkg.env <- new.env()
 .onLoad = function(libname, pkgname){
     suppressMessages(setAccess('public'))
     pkg.env$nldi_base <- "https://labs.waterdata.usgs.gov/api/nldi/linked-data/"
-    pkg.env$local_sf <- requireNamespace("sf")
-    pkg.env$current_nldi <- get_nldi_sources()
+    pkg.env$local_sf <- requireNamespace("sf", quietly = TRUE)
 }

--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -262,7 +262,7 @@ findNLDI <- function(comid = NULL,
 
   # Should sf be used? Both no_sf and pkg.env must agree
   use_sf = all(pkg.env$local_sf, !no_sf)
-
+  
   # Should the basin be identified?
   getBasin = ("basin" %in% find)
 
@@ -319,6 +319,10 @@ findNLDI <- function(comid = NULL,
   # Reset (if needed)
   start_type = names(starter)
 
+  if(is.null(pkg.env$current_nldi)) {
+    pkg.env$current_nldi <- get_nldi_sources()
+  }
+  
   # Defining the origin URL.
     #  Align request with formal name from offerings
     # If NWIS, add "USGS-" prefix


### PR DESCRIPTION
Minor changes in loading behavior to quite some warnings and avoid a web-service call in .onLoad.

Tested all the examples and am happy with this for release if you are @ldecicco-USGS 