### PR TITLE
avoid partial matching of feature in findNLDI

### DIFF
--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -343,7 +343,7 @@ findNLDI <- function(comid = NULL,
     #  Align request with formal name from sources
     #  If NWIS, add "USGS-" prefix
   start_url = paste0(
-    valid_ask(pkg.env$current_nldi, type = start_type)$good$feature, "/",
+    valid_ask(pkg.env$current_nldi, type = start_type)$good$features, "/",
     ifelse(start_type == "nwis", paste0("USGS-", starter), starter), "/"
   )
 


### PR DESCRIPTION
This PR fixes this warning being thrown when running `findNLDI`:

> Warning message:
partial match of 'feature' to 'features' 

Note that the output of `valid_ask` contains a `features` object not a `feature` object. For example,

```r
valid_ask(pkg.env$current_nldi, type = start_type)$good

source sourceName features
nwissite NWIS Sites https://labs.waterdata.usgs.gov/api/nldi/linked-data/nwissite
```