### PR TITLE
fix another stray headerInfo #534

### DIFF
--- a/R/readNWISunit.r
+++ b/R/readNWISunit.r
@@ -317,7 +317,7 @@ readNWISmeas <- function (siteNumbers,startDate="",endDate="", tz="UTC", expande
     url <- attr(data, "url")
     comment <- attr(data, "comment")
     queryTime <- attr(data, "queryTime")
-    header <- attr(data, "header")
+    header <- attr(data, "headerInfo")
     
     if(convertType){
       data$measurement_dateTime <- data$measurement_dt


### PR DESCRIPTION
See #534 

Also:
```r
names(attributes(data))
[1] "names"      "class"      "row.names"  "queryTime"  "url"        "headerInfo"
```