### PR TITLE
Failing gracefully

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,9 +20,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-16.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
-          - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dataRetrieval
 Type: Package
 Title: Retrieval Functions for USGS and EPA Hydrologic and Water Quality Data
-Version: 2.7.9.0001
+Version: 2.7.10
 Authors@R: c(
     person("Laura", "DeCicco", role = c("aut","cre"),
             email = "ldecicco@usgs.gov",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+dataRetrieval 2.8.10
+==================
+* Functions that come back from a server that had and error now return with a message and NULL rather than error.
+
 dataRetrieval 2.7.9
 ===================
 * Fix bug caused by changes in NLDI services

--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -230,12 +230,13 @@ valid_ask = function(all, type) {
 #' # Find Features / Define origin features
 #'
 #' ## Find feature by COMID
+#' if(!httr::http_error("https://labs.waterdata.usgs.gov/api/nldi/linked-data")){
 #'  findNLDI(comid = 101)
-#'
+#'  
 #' ## Find feature by NWIS ID
-#'  findNLDI(nwis = '11120000')
-#'
-#' ## Find feature by WQP ID
+#'   findNLDI(nwis = '11120000')
+#' 
+#' ## Find feature by WQP ID 
 #'  findNLDI(wqp = 'USGS-04024315')
 #'
 #' ## Find feature by LOCATION
@@ -266,6 +267,7 @@ valid_ask = function(all, type) {
 #' # Control Distance
 #' ## Limit search to 50 km
 #'  findNLDI(comid = 101, nav = "DM", find = c("nwis", "wqp", "flowlines"), distance_km = 50)
+#'}
 #'}
 findNLDI <- function(comid = NULL,
                      nwis = NULL,

--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -230,7 +230,6 @@ valid_ask = function(all, type) {
 #' # Find Features / Define origin features
 #'
 #' ## Find feature by COMID
-#' if(!httr::http_error("https://labs.waterdata.usgs.gov/api/nldi/linked-data")){
 #'  findNLDI(comid = 101)
 #'  
 #' ## Find feature by NWIS ID
@@ -267,7 +266,6 @@ valid_ask = function(all, type) {
 #' # Control Distance
 #' ## Limit search to 50 km
 #'  findNLDI(comid = 101, nav = "DM", find = c("nwis", "wqp", "flowlines"), distance_km = 50)
-#'}
 #'}
 findNLDI <- function(comid = NULL,
                      nwis = NULL,

--- a/R/getWebServiceData.R
+++ b/R/getWebServiceData.R
@@ -18,9 +18,7 @@
 #' property <- '00060'
 #' obs_url <- constructNWISURL(siteNumber,property,startDate,endDate,'dv')
 #' \donttest{
-#' if(!httr::http_error(obs_url)){
 #'   rawData <- getWebServiceData(obs_url)
-#' }
 #' }
 getWebServiceData <- function(obs_url, ...){
   
@@ -35,10 +33,12 @@ getWebServiceData <- function(obs_url, ...){
     response400 <- httr::content(returnedList, type="text", encoding = "UTF-8")
     statusReport <- xml_text(xml_child(read_xml(response400), 2)) # making assumption that - body is second node
     statusMsg <- gsub(pattern=", server=.*", replacement="", x = statusReport)
-    stop(statusMsg)
+    message(statusMsg)
+    return(invisible(NULL))
   } else if(httr::status_code(returnedList) != 200){
     message("For: ", obs_url,"\n")
-    httr::stop_for_status(returnedList)
+    httr::message_for_status(returnedList)
+    return(invisible(NULL))
   } else {
     headerInfo <- httr::headers(returnedList)
 

--- a/R/getWebServiceData.R
+++ b/R/getWebServiceData.R
@@ -41,7 +41,12 @@ getWebServiceData <- function(obs_url, ...){
     return(invisible(NULL))
   } else {
     headerInfo <- httr::headers(returnedList)
-
+    
+    if(!"content-type" %in% names(headerInfo)){
+      message("Unknown content, returning NULL")
+      return(invisible(NULL))
+    }
+    
     if(headerInfo$`content-type` %in% c("text/tab-separated-values;charset=UTF-8")){
       returnedDoc <- httr::content(returnedList, type="text",encoding = "UTF-8")
     } else if (headerInfo$`content-type` %in% 

--- a/R/getWebServiceData.R
+++ b/R/getWebServiceData.R
@@ -18,7 +18,9 @@
 #' property <- '00060'
 #' obs_url <- constructNWISURL(siteNumber,property,startDate,endDate,'dv')
 #' \donttest{
-#' rawData <- getWebServiceData(obs_url)
+#' if(!httr::http_error(obs_url)){
+#'   rawData <- getWebServiceData(obs_url)
+#' }
 #' }
 getWebServiceData <- function(obs_url, ...){
   

--- a/R/importNGWMN_wml2.R
+++ b/R/importNGWMN_wml2.R
@@ -25,9 +25,9 @@
 #' "observedProperty=urn:ogc:def:property:OGC:GroundWaterLevel",
 #' "responseFormat=text/xml",
 #' "featureOfInterest=VW_GWDP_GEOSERVER.USGS.403836085374401",sep="&")
-#' if(!httr::http_error(obs_url)){
-#'   data_returned <- importNGWMN(obs_url)
-#' }
+#' 
+#'  data_returned <- importNGWMN(obs_url)
+#' 
 #' }
 #' 
 importNGWMN <- function(input, asDateTime=FALSE, tz="UTC"){

--- a/R/importNGWMN_wml2.R
+++ b/R/importNGWMN_wml2.R
@@ -44,7 +44,9 @@ importNGWMN <- function(input, asDateTime=FALSE, tz="UTC"){
     raw <- TRUE
   } else {
     returnedDoc <- getWebServiceData(input, encoding='gzip')
-    
+    if(is.null(returnedDoc)){
+      return(invisible(NULL))
+    }
     returnedDoc <- xml_root(returnedDoc)
     
   }

--- a/R/importNGWMN_wml2.R
+++ b/R/importNGWMN_wml2.R
@@ -144,9 +144,9 @@ importNGWMN <- function(input, asDateTime=FALSE, tz="UTC"){
 #'      "statCd=00003",
 #'      "parameterCd=00060",sep="&")
 #' \donttest{
-#' if(!httr::http_error(URL)){
-#'   timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
-#' } 
+#' 
+#' timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
+#'  
 #' }
 importWaterML2 <- function(input, asDateTime=FALSE, tz="UTC") {
   

--- a/R/importNGWMN_wml2.R
+++ b/R/importNGWMN_wml2.R
@@ -25,8 +25,9 @@
 #' "observedProperty=urn:ogc:def:property:OGC:GroundWaterLevel",
 #' "responseFormat=text/xml",
 #' "featureOfInterest=VW_GWDP_GEOSERVER.USGS.403836085374401",sep="&")
-#' data <- importNGWMN(obs_url)
-#' 
+#' if(!httr::http_error(obs_url)){
+#'   data_returned <- importNGWMN(obs_url)
+#' }
 #' }
 #' 
 importNGWMN <- function(input, asDateTime=FALSE, tz="UTC"){
@@ -141,8 +142,10 @@ importNGWMN <- function(input, asDateTime=FALSE, tz="UTC"){
 #'      "statCd=00003",
 #'      "parameterCd=00060",sep="&")
 #' \donttest{
-#' timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
+#' if(!httr::http_error(URL)){
+#'   timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
 #' } 
+#' }
 importWaterML2 <- function(input, asDateTime=FALSE, tz="UTC") {
   
   returnedDoc <- check_if_xml(input)

--- a/R/importRDB1.r
+++ b/R/importRDB1.r
@@ -52,24 +52,34 @@
 #' obs_url <- constructNWISURL(site_id,property,
 #'          startDate,endDate,"dv",format="tsv")
 #' \donttest{
-#' data <- importRDB1(obs_url)
+#' if(!httr::http_error(obs_url)){
+#'   data <- importRDB1(obs_url)
+#' }
 #' 
 #' urlMultiPcodes <- constructNWISURL("04085427",c("00060","00010"),
 #'          startDate,endDate,"dv",statCd=c("00003","00001"),"tsv")
-#' multiData <- importRDB1(urlMultiPcodes)
+#' if(!httr::http_error(urlMultiPcodes)){
+#'   multiData <- importRDB1(urlMultiPcodes)
+#' }
 #' unitDataURL <- constructNWISURL(site_id,property,
 #'          "2020-10-30","2020-11-01","uv",format="tsv") #includes timezone switch
-#' unitData <- importRDB1(unitDataURL, asDateTime=TRUE)
+#' if(!httr::http_error(unitDataURL)){
+#'   unitData <- importRDB1(unitDataURL, asDateTime=TRUE)
+#' }
 #' qwURL <- constructNWISURL(c('04024430','04024000'),
 #'           c('34247','30234','32104','34220'),
-#'          "2010-11-03","","qw",format="rdb") 
-#' qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
+#'          "2010-11-03","","qw",format="rdb")
+#' if(!httr::http_error(qwURL)){ 
+#'   qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
+#' }
 #' iceSite <- '04024000'
 #' start <- "2015-11-09"
 #' end <- "2015-11-24"
 #' urlIce <- constructNWISURL(iceSite,"00060",start, end,"uv",format="tsv")
-#' ice <- importRDB1(urlIce, asDateTime=TRUE)
-#' iceNoConvert <- importRDB1(urlIce, convertType=FALSE)
+#' if(!httr::http_error(urlIce)){
+#'   ice <- importRDB1(urlIce, asDateTime=TRUE)
+#'   iceNoConvert <- importRDB1(urlIce, convertType=FALSE)
+#' }
 #' }
 #' # User file:
 #' filePath <- system.file("extdata", package="dataRetrieval")

--- a/R/importRDB1.r
+++ b/R/importRDB1.r
@@ -103,6 +103,9 @@ importRDB1 <- function(obs_url, asDateTime=TRUE, convertType = TRUE, tz="UTC"){
     doc <- getWebServiceData(obs_url,
                              httr::write_disk(f),
                              encoding='gzip')
+    if(is.null(doc)){
+      return(invisible(NULL))
+    }
     if("warn" %in% names(attr(doc, "headerInfo"))){
       data <- data.frame()
       attr(data, "headerInfo") <- attr(doc,"headerInfo")

--- a/R/importRDB1.r
+++ b/R/importRDB1.r
@@ -52,34 +52,33 @@
 #' obs_url <- constructNWISURL(site_id,property,
 #'          startDate,endDate,"dv",format="tsv")
 #' \donttest{
-#' if(!httr::http_error(obs_url)){
-#'   data <- importRDB1(obs_url)
-#' }
+#' data <- importRDB1(obs_url)
+#' 
 #' 
 #' urlMultiPcodes <- constructNWISURL("04085427",c("00060","00010"),
 #'          startDate,endDate,"dv",statCd=c("00003","00001"),"tsv")
-#' if(!httr::http_error(urlMultiPcodes)){
+#' 
 #'   multiData <- importRDB1(urlMultiPcodes)
-#' }
+#' 
 #' unitDataURL <- constructNWISURL(site_id,property,
 #'          "2020-10-30","2020-11-01","uv",format="tsv") #includes timezone switch
-#' if(!httr::http_error(unitDataURL)){
+#' 
 #'   unitData <- importRDB1(unitDataURL, asDateTime=TRUE)
-#' }
+#' 
 #' qwURL <- constructNWISURL(c('04024430','04024000'),
 #'           c('34247','30234','32104','34220'),
 #'          "2010-11-03","","qw",format="rdb")
-#' if(!httr::http_error(qwURL)){ 
-#'   qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
-#' }
+#' 
+#' qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
+#' 
 #' iceSite <- '04024000'
 #' start <- "2015-11-09"
 #' end <- "2015-11-24"
 #' urlIce <- constructNWISURL(iceSite,"00060",start, end,"uv",format="tsv")
-#' if(!httr::http_error(urlIce)){
+#' 
 #'   ice <- importRDB1(urlIce, asDateTime=TRUE)
 #'   iceNoConvert <- importRDB1(urlIce, convertType=FALSE)
-#' }
+#' 
 #' }
 #' # User file:
 #' filePath <- system.file("extdata", package="dataRetrieval")

--- a/R/importWQP.R
+++ b/R/importWQP.R
@@ -22,20 +22,17 @@
 #' \donttest{
 #' rawSampleURL <- constructWQPURL('USGS-01594440','01075', '', '')
 #' 
-#' if(!httr::http_error(rawSampleURL)){
-#'   rawSample <- importWQP(rawSampleURL)
-#' }
+#' rawSample <- importWQP(rawSampleURL)
 #' 
 #' rawSampleURL_NoZip <- constructWQPURL('USGS-01594440','01075', '', '', zip=FALSE)
-#' if(!httr::http_error(rawSampleURL_NoZip)){
-#'   rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
-#' }
-#' #' 
+#' 
+#' rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
+#' 
 #' STORETex <- constructWQPURL('WIDNR_WQX-10032762','Specific conductance', '', '')
-#' if(!httr::http_error(STORETex)){
-#'   STORETdata <- importWQP(STORETex)
+#' 
+#'  STORETdata <- importWQP(STORETex)
 #' }
-#' }
+#' 
 importWQP <- function(obs_url, zip=TRUE, tz="UTC", 
                       csv=FALSE){
   

--- a/R/importWQP.R
+++ b/R/importWQP.R
@@ -52,6 +52,9 @@ importWQP <- function(obs_url, zip=TRUE, tz="UTC",
       doc <- getWebServiceData(obs_url, 
                                httr::write_disk(temp),
                                httr::accept("application/zip"))
+      if(is.null(doc)){
+        return(invisible(NULL))
+      }
       headerInfo <- httr::headers(doc)
       doc <- utils::unzip(temp, exdir=tempdir())
       unlink(temp)
@@ -59,6 +62,9 @@ importWQP <- function(obs_url, zip=TRUE, tz="UTC",
     } else {
       doc <- getWebServiceData(obs_url, 
                                httr::accept("text/tsv"))
+      if(is.null(doc)){
+        return(invisible(NULL))
+      }
       headerInfo <- attr(doc, "headerInfo")
     }
 

--- a/R/importWQP.R
+++ b/R/importWQP.R
@@ -22,13 +22,19 @@
 #' \donttest{
 #' rawSampleURL <- constructWQPURL('USGS-01594440','01075', '', '')
 #' 
-#' rawSample <- importWQP(rawSampleURL)
+#' if(!httr::http_error(rawSampleURL)){
+#'   rawSample <- importWQP(rawSampleURL)
+#' }
 #' 
 #' rawSampleURL_NoZip <- constructWQPURL('USGS-01594440','01075', '', '', zip=FALSE)
-#' rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
-#' 
+#' if(!httr::http_error(rawSampleURL_NoZip)){
+#'   rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
+#' }
+#' #' 
 #' STORETex <- constructWQPURL('WIDNR_WQX-10032762','Specific conductance', '', '')
-#' STORETdata <- importWQP(STORETex)
+#' if(!httr::http_error(STORETex)){
+#'   STORETdata <- importWQP(STORETex)
+#' }
 #' }
 importWQP <- function(obs_url, zip=TRUE, tz="UTC", 
                       csv=FALSE){

--- a/R/importWaterML1.r
+++ b/R/importWaterML1.r
@@ -115,7 +115,7 @@ importWaterML1 <- function(obs_url,asDateTime=FALSE, tz="UTC"){
   
   timeSeries <- xml_find_all(returnedDoc, ".//ns1:timeSeries") #each parameter/site combo
   
-  #some intial attributes
+  #some initial attributes
   queryNodes <- xml_children(xml_find_all(returnedDoc,".//ns1:queryInfo"))
   notes <- queryNodes[xml_name(queryNodes)=="note"]
   noteTitles <- xml_attrs(notes)
@@ -124,7 +124,10 @@ importWaterML1 <- function(obs_url,asDateTime=FALSE, tz="UTC"){
   names(noteList) <- noteTitles
   
   if(0 == length(timeSeries)){
-    df <- data.frame()
+    df <- data.frame(agency_cd = character(),
+                     site_no = character(),
+                     dateTime = as.POSIXct(character()),
+                     tz_cd = character())
     attr(df, "queryInfo") <- noteList
     if(!raw){
       attr(df, "url") <- obs_url

--- a/R/importWaterML1.r
+++ b/R/importWaterML1.r
@@ -413,7 +413,12 @@ check_if_xml <- function(obs_url){
   } else if(inherits(obs_url, c("xml_node", "xml_nodeset"))) {
     returnedDoc <- obs_url
   } else {
-    returnedDoc <- xml_root(getWebServiceData(obs_url, encoding='gzip'))
+    
+    doc <- getWebServiceData(obs_url, encoding='gzip')
+    if(is.null(doc)){
+      return(invisible(NULL))
+    }
+    returnedDoc <- xml_root(doc)
   }
   return(returnedDoc)
 }

--- a/R/readNGWMNdata.R
+++ b/R/readNGWMNdata.R
@@ -152,18 +152,14 @@ readNGWMNlevels <- function(siteNumbers, asDateTime = TRUE, tz = "UTC"){
 #' }
 #' @examples 
 #' \donttest{
-#' #one site
-#' if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
-#'   site <- "USGS.430427089284901"
-#'   oneSite <- readNGWMNsites(siteNumbers = site)   
-#' }
+#' #one site 
+#' site <- "USGS.430427089284901"
+#' oneSite <- readNGWMNsites(siteNumbers = site)   
 #' 
-#'  
 #' #non-USGS site
-#' if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
-#'   site <- "MBMG.103306"
-#'   siteInfo <- readNGWMNsites(siteNumbers = site)
-#' }
+#' site <- "MBMG.103306"
+#' siteInfo <- readNGWMNsites(siteNumbers = site)
+#' 
 #' }
 readNGWMNsites <- function(siteNumbers){
   sites <- readNGWMNdata(siteNumbers = siteNumbers, service = "featureOfInterest")

--- a/R/readNGWMNdata.R
+++ b/R/readNGWMNdata.R
@@ -153,13 +153,17 @@ readNGWMNlevels <- function(siteNumbers, asDateTime = TRUE, tz = "UTC"){
 #' @examples 
 #' \donttest{
 #' #one site
-#' site <- "USGS.430427089284901"
-#' oneSite <- readNGWMNsites(siteNumbers = site)
+#' if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
+#'   site <- "USGS.430427089284901"
+#'   oneSite <- readNGWMNsites(siteNumbers = site)   
+#' }
 #' 
+#'  
 #' #non-USGS site
-#' site <- "MBMG.103306"
-#' siteInfo <- readNGWMNsites(siteNumbers = site)
-#' 
+#' if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
+#'   site <- "MBMG.103306"
+#'   siteInfo <- readNGWMNsites(siteNumbers = site)
+#' }
 #' }
 readNGWMNsites <- function(siteNumbers){
   sites <- readNGWMNdata(siteNumbers = siteNumbers, service = "featureOfInterest")

--- a/R/readNWISdata.r
+++ b/R/readNWISdata.r
@@ -56,7 +56,7 @@
 #' @examples
 #' \donttest{
 #' # Examples not run for time considerations
-#' if(!httr::http_error("https://waterservices.usgs.gov")){
+#' 
 #' dataTemp <- readNWISdata(stateCd="OH",parameterCd="00010", service="dv")
 #' instFlow <- readNWISdata(sites="05114000", service="iv", 
 #'                    parameterCd="00060", 
@@ -117,10 +117,7 @@
 #' va_counties <- c("51001","51003","51005","51007","51009","51011","51013","51015")
 #' va_counties_data <- readNWISdata(startDate = "2015-01-01", endDate = "2015-12-31", 
 #' parameterCd = "00060", countycode = va_counties)
-#' }
-#' 
-#' 
-#' if(!httr::http_error("https://nwis.waterdata.usgs.gov")){
+#'  
 #' site_id <- '01594440'
 #' rating_curve <- readNWISdata(service = "rating", site_no = site_id, file_type="base")
 #' all_sites_base <- readNWISdata(service = "rating", file_type="base")
@@ -132,7 +129,7 @@
 #'                           site_no = c("01594440","040851325"),
 #'                           range_selection = "data_range")
 #' 
-#' }
+#' 
 #' }
 readNWISdata <- function(..., asDateTime=TRUE,convertType=TRUE,tz="UTC"){
   

--- a/R/readNWISdata.r
+++ b/R/readNWISdata.r
@@ -56,6 +56,7 @@
 #' @examples
 #' \donttest{
 #' # Examples not run for time considerations
+#' if(!httr::http_error("https://waterservices.usgs.gov")){
 #' dataTemp <- readNWISdata(stateCd="OH",parameterCd="00010", service="dv")
 #' instFlow <- readNWISdata(sites="05114000", service="iv", 
 #'                    parameterCd="00060", 
@@ -76,32 +77,35 @@
 #' 
 #' startDate <- as.Date("2013-10-01")
 #' endDate <- as.Date("2014-09-30")
-#' waterYear <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010", 
+#' waterYear <- readNWISdata(bBox=c(-83,36.5,-82.5,36.75), parameterCd="00010", 
 #'                   service="dv", startDate=startDate, endDate=endDate)
 #' siteInfo <- readNWISdata(stateCd="WI", parameterCd="00010",
 #'                   hasDataTypeCd="iv", service="site")
-#' temp <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010", service="site", 
+#' temp <- readNWISdata(bBox=c(-83,36.5,-82.5,36.75), parameterCd="00010", service="site", 
 #'                    seriesCatalogOutput=TRUE)
-#' wiGWL <- readNWISdata(stateCd="WI",service="gwlevels")
-#' meas <- readNWISdata(state_cd="WI",service="measurements",format="rdb_expanded")
+#' wiGWL <- readNWISdata(stateCd = "WI", service = "gwlevels")
+#' meas <- readNWISdata(state_cd = "WI", service = "measurements",
+#'                      format = "rdb_expanded")
 #' 
-#' waterYearStat <- readNWISdata(site=c("01646500"),service="stat",statReportType="annual",
-#'                  statYearType="water", missingData="on")
+#' waterYearStat <- readNWISdata(site = c("01646500"), 
+#'                               service = "stat",
+#'                               statReportType="annual",
+#'                               statYearType = "water",
+#'                               missingData = "on")
 #' monthlyStat <- readNWISdata(site=c("01646500"),
 #'                             service="stat",
-#'                             statReportType="monthly")                                   
-#' dailyStat <- readNWISdata(site=c("01646500"),
-#'                           service="stat",
-#'                           statReportType="daily",
-#'                           statType=c("p25","p50","p75","min","max"),
-#'                           parameterCd="00060")
+#'                             statReportType="monthly")  
+#'                                                              
+#' dailyStat <- readNWISdata(site = c("01646500"),
+#'                           service = "stat",
+#'                           statReportType = "daily",
+#'                           statType = c("p25","p50","p75","min","max"),
+#'                           parameterCd = "00060")
 #'
-#' dailyRI <- readNWISdata(stateCd = "Rhode Island", parameterCd = "00060")
-#'
-#' arg.list <- list(site="03111548",
-#'                  statReportType="daily",
-#'                  statType=c("p25","p50","p75","min","max"),
-#'                  parameterCd="00060")
+#' arg.list <- list(site = "03111548",
+#'                  statReportType = "daily",
+#'                  statType = c("p25","p50","p75","min","max"),
+#'                  parameterCd = "00060")
 #' allDailyStats_2 <- readNWISdata(arg.list, service="stat")
 #'
 #' #' # use county names to get data
@@ -113,20 +117,22 @@
 #' va_counties <- c("51001","51003","51005","51007","51009","51011","51013","51015")
 #' va_counties_data <- readNWISdata(startDate = "2015-01-01", endDate = "2015-12-31", 
 #' parameterCd = "00060", countycode = va_counties)
+#' }
+#' 
+#' 
+#' if(!httr::http_error("https://nwis.waterdata.usgs.gov")){
 #' site_id <- '01594440'
 #' rating_curve <- readNWISdata(service = "rating", site_no = site_id, file_type="base")
 #' all_sites_base <- readNWISdata(service = "rating", file_type="base")
 #' all_sites_core <- readNWISdata(service = "rating", file_type="corr")
 #' all_sites_exsa <- readNWISdata(service = "rating", file_type="exsa")
 #' all_sites_24hrs <- readNWISdata(service = "rating", file_type="exsa", period = 24)
-#' 
-#' today <- readNWISdata(service="iv", startDate = Sys.Date(), 
-#'                       parameterCd = "00060", siteNumber = "05114000")
 #'                       
 #' peak_data <- readNWISdata(service = "peak", 
 #'                           site_no = c("01594440","040851325"),
 #'                           range_selection = "data_range")
 #' 
+#' }
 #' }
 readNWISdata <- function(..., asDateTime=TRUE,convertType=TRUE,tz="UTC"){
   

--- a/R/readNWISpCode.r
+++ b/R/readNWISpCode.r
@@ -21,6 +21,7 @@
 #' @export
 #' @seealso \code{\link{importRDB1}}
 #' @examples
+#' if(!httr::http_error("https://waterservices.usgs.gov")){
 #' paramINFO <- readNWISpCode(c('01075','00060','00931'))
 #' paramINFO <- readNWISpCode(c('01075','00060','00931', NA))
 readNWISpCode <- function(parameterCd){

--- a/R/readNWISpCode.r
+++ b/R/readNWISpCode.r
@@ -21,7 +21,7 @@
 #' @export
 #' @seealso \code{\link{importRDB1}}
 #' @examples
-#' if(!httr::http_error("https://waterservices.usgs.gov")){
+#' 
 #' paramINFO <- readNWISpCode(c('01075','00060','00931'))
 #' paramINFO <- readNWISpCode(c('01075','00060','00931', NA))
 readNWISpCode <- function(parameterCd){

--- a/R/readNWISsite.r
+++ b/R/readNWISsite.r
@@ -61,10 +61,10 @@
 #' @export
 #' @examples
 #' \donttest{
-#' try({
+#' 
 #' siteINFO <- readNWISsite('05114000')
 #' siteINFOMulti <- readNWISsite(c('05114000','09423350'))
-#' })
+#' 
 #' }
 readNWISsite <- function(siteNumbers){
   

--- a/R/readNWISsite.r
+++ b/R/readNWISsite.r
@@ -61,8 +61,10 @@
 #' @export
 #' @examples
 #' \donttest{
+#' try({
 #' siteINFO <- readNWISsite('05114000')
 #' siteINFOMulti <- readNWISsite(c('05114000','09423350'))
+#' })
 #' }
 readNWISsite <- function(siteNumbers){
   

--- a/R/readNWISunit.r
+++ b/R/readNWISunit.r
@@ -54,7 +54,7 @@
 #' startDate <- "2014-10-10"
 #' endDate <- "2014-10-10"
 #' \donttest{
-#' try({
+#' 
 #' rawData <- readNWISuv(site_id,parameterCd,startDate,endDate)
 #' 
 #' rawData_today <- readNWISuv(site_id, parameterCd, Sys.Date(),Sys.Date())
@@ -69,7 +69,7 @@
 #' # Adding 'Z' to the time indicates to the web service to call the data with UTC time:
 #' GMTdata <- readNWISuv(site_id,parameterCd,
 #'                            "2014-10-10T00:00Z", "2014-10-10T23:59Z")
-#' })
+#' 
 #' }
 readNWISuv <- function (siteNumbers,parameterCd,startDate="",endDate="", tz="UTC"){  
   

--- a/R/readNWISunit.r
+++ b/R/readNWISunit.r
@@ -54,6 +54,7 @@
 #' startDate <- "2014-10-10"
 #' endDate <- "2014-10-10"
 #' \donttest{
+#' try({
 #' rawData <- readNWISuv(site_id,parameterCd,startDate,endDate)
 #' 
 #' rawData_today <- readNWISuv(site_id, parameterCd, Sys.Date(),Sys.Date())
@@ -68,8 +69,8 @@
 #' # Adding 'Z' to the time indicates to the web service to call the data with UTC time:
 #' GMTdata <- readNWISuv(site_id,parameterCd,
 #'                            "2014-10-10T00:00Z", "2014-10-10T23:59Z")
+#' })
 #' }
-#' 
 readNWISuv <- function (siteNumbers,parameterCd,startDate="",endDate="", tz="UTC"){  
   
   if(as.character(startDate) == "" || (as.Date(startDate) <= Sys.Date()-120)){

--- a/R/whatNWISData.r
+++ b/R/whatNWISData.r
@@ -51,7 +51,7 @@
 #' @export
 #' @examples
 #' \donttest{
-#' try({
+#' 
 #' availableData <- whatNWISdata(siteNumber = '05114000')
 #' # To find just unit value ('instantaneous') data:
 #' uvData <- whatNWISdata(siteNumber = '05114000',service="uv")
@@ -59,7 +59,7 @@
 #' flowAndTemp <- whatNWISdata(stateCd = "WI", service = "uv", 
 #'                              parameterCd = c("00060","00010"),
 #'                              statCd = "00003")
-#' })
+#' 
 #' }
 whatNWISdata <- function(..., convertType=TRUE){
   

--- a/R/whatNWISData.r
+++ b/R/whatNWISData.r
@@ -51,6 +51,7 @@
 #' @export
 #' @examples
 #' \donttest{
+#' try({
 #' availableData <- whatNWISdata(siteNumber = '05114000')
 #' # To find just unit value ('instantaneous') data:
 #' uvData <- whatNWISdata(siteNumber = '05114000',service="uv")
@@ -58,6 +59,7 @@
 #' flowAndTemp <- whatNWISdata(stateCd = "WI", service = "uv", 
 #'                              parameterCd = c("00060","00010"),
 #'                              statCd = "00003")
+#' })
 #' }
 whatNWISdata <- function(..., convertType=TRUE){
   

--- a/R/whatNWISsites.R
+++ b/R/whatNWISsites.R
@@ -30,10 +30,10 @@
 #' 
 #' @examples
 #' \donttest{
-#' try({
+#' 
 #' siteListPhos <- whatNWISsites(stateCd="OH",parameterCd="00665")
 #' oneSite <- whatNWISsites(sites="05114000")
-#' })
+#' 
 #' }
 whatNWISsites <- function(...){
   

--- a/R/whatNWISsites.R
+++ b/R/whatNWISsites.R
@@ -45,7 +45,9 @@ whatNWISsites <- function(...){
   urlCall <- drURL('site',Access=pkg.env$access, arg.list = values)
 
   rawData <- getWebServiceData(urlCall, encoding='gzip')
-
+  if(is.null(rawData)){
+    return(invisible(NULL))
+  }
   doc <- xml_root(rawData)
   siteCategories <- xml_children(doc)
   retVal <- NULL

--- a/R/whatNWISsites.R
+++ b/R/whatNWISsites.R
@@ -30,8 +30,10 @@
 #' 
 #' @examples
 #' \donttest{
+#' try({
 #' siteListPhos <- whatNWISsites(stateCd="OH",parameterCd="00665")
 #' oneSite <- whatNWISsites(sites="05114000")
+#' })
 #' }
 whatNWISsites <- function(...){
   

--- a/R/whatWQPdata.R
+++ b/R/whatWQPdata.R
@@ -3,12 +3,12 @@
 #' @export
 #' @examples
 #' \donttest{
-#' try({
+#' 
 #' site1 <- whatWQPsamples(siteid="USGS-01594440")
 #' 
 #' type <- "Stream"
 #' sites <- whatWQPsamples(countycode="US:55:025",siteType=type)
-#' })
+#' 
 #' }
 whatWQPsamples <- function(...){
   

--- a/R/whatWQPdata.R
+++ b/R/whatWQPdata.R
@@ -3,10 +3,12 @@
 #' @export
 #' @examples
 #' \donttest{
+#' try({
 #' site1 <- whatWQPsamples(siteid="USGS-01594440")
 #' 
 #' type <- "Stream"
 #' sites <- whatWQPsamples(countycode="US:55:025",siteType=type)
+#' })
 #' }
 whatWQPsamples <- function(...){
   

--- a/R/whatWQPdata.R
+++ b/R/whatWQPdata.R
@@ -161,6 +161,9 @@ whatWQPdata <- function(..., saveFile = tempfile()){
   }
 
   doc <- getWebServiceData(baseURL, httr::write_disk(saveFile_zip))
+  if(is.null(doc)){
+    return(invisible(NULL))
+  }
   headerInfo <- attr(doc, "headerInfo")
   
   if(headerInfo$`total-site-count` == 0){

--- a/R/whatWQPsites.R
+++ b/R/whatWQPsites.R
@@ -58,12 +58,14 @@
 #' @seealso whatNWISdata
 #' @examples
 #' \donttest{
+#' try({
 #' site1 <- whatWQPsites(siteid="USGS-01594440")
 #' 
 #' type <- "Stream"
 #' sites <- whatWQPsites(countycode="US:55:025",
 #'                       characteristicName = "Phosphorus",
 #'                       siteType=type)
+#' })
 #' }
 whatWQPsites <- function(...){
 

--- a/R/whatWQPsites.R
+++ b/R/whatWQPsites.R
@@ -58,14 +58,14 @@
 #' @seealso whatNWISdata
 #' @examples
 #' \donttest{
-#' try({
+#' 
 #' site1 <- whatWQPsites(siteid="USGS-01594440")
 #' 
 #' type <- "Stream"
 #' sites <- whatWQPsites(countycode="US:55:025",
 #'                       characteristicName = "Phosphorus",
 #'                       siteType=type)
-#' })
+#' 
 #' }
 whatWQPsites <- function(...){
 

--- a/man/findNLDI.Rd
+++ b/man/findNLDI.Rd
@@ -69,7 +69,6 @@ arguments: comid, nwis, huc12, wqp, location, and start.
 # Find Features / Define origin features
 
 ## Find feature by COMID
-if(!httr::http_error("https://labs.waterdata.usgs.gov/api/nldi/linked-data")){
  findNLDI(comid = 101)
  
 ## Find feature by NWIS ID
@@ -106,7 +105,6 @@ if(!httr::http_error("https://labs.waterdata.usgs.gov/api/nldi/linked-data")){
 # Control Distance
 ## Limit search to 50 km
  findNLDI(comid = 101, nav = "DM", find = c("nwis", "wqp", "flowlines"), distance_km = 50)
-}
 }
 }
 \keyword{nldi}

--- a/man/findNLDI.Rd
+++ b/man/findNLDI.Rd
@@ -69,12 +69,13 @@ arguments: comid, nwis, huc12, wqp, location, and start.
 # Find Features / Define origin features
 
 ## Find feature by COMID
+if(!httr::http_error("https://labs.waterdata.usgs.gov/api/nldi/linked-data")){
  findNLDI(comid = 101)
-
+ 
 ## Find feature by NWIS ID
- findNLDI(nwis = '11120000')
+  findNLDI(nwis = '11120000')
 
-## Find feature by WQP ID
+## Find feature by WQP ID 
  findNLDI(wqp = 'USGS-04024315')
 
 ## Find feature by LOCATION
@@ -105,6 +106,7 @@ arguments: comid, nwis, huc12, wqp, location, and start.
 # Control Distance
 ## Limit search to 50 km
  findNLDI(comid = 101, nav = "DM", find = c("nwis", "wqp", "flowlines"), distance_km = 50)
+}
 }
 }
 \keyword{nldi}

--- a/man/getWebServiceData.Rd
+++ b/man/getWebServiceData.Rd
@@ -26,8 +26,6 @@ offering <- '00003'
 property <- '00060'
 obs_url <- constructNWISURL(siteNumber,property,startDate,endDate,'dv')
 \donttest{
-if(!httr::http_error(obs_url)){
   rawData <- getWebServiceData(obs_url)
-}
 }
 }

--- a/man/getWebServiceData.Rd
+++ b/man/getWebServiceData.Rd
@@ -26,6 +26,8 @@ offering <- '00003'
 property <- '00060'
 obs_url <- constructNWISURL(siteNumber,property,startDate,endDate,'dv')
 \donttest{
-rawData <- getWebServiceData(obs_url)
+if(!httr::http_error(obs_url)){
+  rawData <- getWebServiceData(obs_url)
+}
 }
 }

--- a/man/importNGWMN.Rd
+++ b/man/importNGWMN.Rd
@@ -32,8 +32,9 @@ obs_url <- paste("https://cida.usgs.gov/ngwmn_cache/sos?request=GetObservation",
 "observedProperty=urn:ogc:def:property:OGC:GroundWaterLevel",
 "responseFormat=text/xml",
 "featureOfInterest=VW_GWDP_GEOSERVER.USGS.403836085374401",sep="&")
-data <- importNGWMN(obs_url)
-
+if(!httr::http_error(obs_url)){
+  data_returned <- importNGWMN(obs_url)
+}
 }
 
 }

--- a/man/importNGWMN.Rd
+++ b/man/importNGWMN.Rd
@@ -32,9 +32,9 @@ obs_url <- paste("https://cida.usgs.gov/ngwmn_cache/sos?request=GetObservation",
 "observedProperty=urn:ogc:def:property:OGC:GroundWaterLevel",
 "responseFormat=text/xml",
 "featureOfInterest=VW_GWDP_GEOSERVER.USGS.403836085374401",sep="&")
-if(!httr::http_error(obs_url)){
-  data_returned <- importNGWMN(obs_url)
-}
+
+ data_returned <- importNGWMN(obs_url)
+
 }
 
 }

--- a/man/importRDB1.Rd
+++ b/man/importRDB1.Rd
@@ -64,24 +64,34 @@ property <- "00060"
 obs_url <- constructNWISURL(site_id,property,
          startDate,endDate,"dv",format="tsv")
 \donttest{
-data <- importRDB1(obs_url)
+if(!httr::http_error(obs_url)){
+  data <- importRDB1(obs_url)
+}
 
 urlMultiPcodes <- constructNWISURL("04085427",c("00060","00010"),
          startDate,endDate,"dv",statCd=c("00003","00001"),"tsv")
-multiData <- importRDB1(urlMultiPcodes)
+if(!httr::http_error(urlMultiPcodes)){
+  multiData <- importRDB1(urlMultiPcodes)
+}
 unitDataURL <- constructNWISURL(site_id,property,
          "2020-10-30","2020-11-01","uv",format="tsv") #includes timezone switch
-unitData <- importRDB1(unitDataURL, asDateTime=TRUE)
+if(!httr::http_error(unitDataURL)){
+  unitData <- importRDB1(unitDataURL, asDateTime=TRUE)
+}
 qwURL <- constructNWISURL(c('04024430','04024000'),
           c('34247','30234','32104','34220'),
-         "2010-11-03","","qw",format="rdb") 
-qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
+         "2010-11-03","","qw",format="rdb")
+if(!httr::http_error(qwURL)){ 
+  qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
+}
 iceSite <- '04024000'
 start <- "2015-11-09"
 end <- "2015-11-24"
 urlIce <- constructNWISURL(iceSite,"00060",start, end,"uv",format="tsv")
-ice <- importRDB1(urlIce, asDateTime=TRUE)
-iceNoConvert <- importRDB1(urlIce, convertType=FALSE)
+if(!httr::http_error(urlIce)){
+  ice <- importRDB1(urlIce, asDateTime=TRUE)
+  iceNoConvert <- importRDB1(urlIce, convertType=FALSE)
+}
 }
 # User file:
 filePath <- system.file("extdata", package="dataRetrieval")

--- a/man/importRDB1.Rd
+++ b/man/importRDB1.Rd
@@ -64,34 +64,33 @@ property <- "00060"
 obs_url <- constructNWISURL(site_id,property,
          startDate,endDate,"dv",format="tsv")
 \donttest{
-if(!httr::http_error(obs_url)){
-  data <- importRDB1(obs_url)
-}
+data <- importRDB1(obs_url)
+
 
 urlMultiPcodes <- constructNWISURL("04085427",c("00060","00010"),
          startDate,endDate,"dv",statCd=c("00003","00001"),"tsv")
-if(!httr::http_error(urlMultiPcodes)){
+
   multiData <- importRDB1(urlMultiPcodes)
-}
+
 unitDataURL <- constructNWISURL(site_id,property,
          "2020-10-30","2020-11-01","uv",format="tsv") #includes timezone switch
-if(!httr::http_error(unitDataURL)){
+
   unitData <- importRDB1(unitDataURL, asDateTime=TRUE)
-}
+
 qwURL <- constructNWISURL(c('04024430','04024000'),
           c('34247','30234','32104','34220'),
          "2010-11-03","","qw",format="rdb")
-if(!httr::http_error(qwURL)){ 
-  qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
-}
+
+qwData <- importRDB1(qwURL, asDateTime=TRUE, tz="America/Chicago")
+
 iceSite <- '04024000'
 start <- "2015-11-09"
 end <- "2015-11-24"
 urlIce <- constructNWISURL(iceSite,"00060",start, end,"uv",format="tsv")
-if(!httr::http_error(urlIce)){
+
   ice <- importRDB1(urlIce, asDateTime=TRUE)
   iceNoConvert <- importRDB1(urlIce, convertType=FALSE)
-}
+
 }
 # User file:
 filePath <- system.file("extdata", package="dataRetrieval")

--- a/man/importWQP.Rd
+++ b/man/importWQP.Rd
@@ -32,13 +32,19 @@ Imports data from the Water Quality Portal based on a specified url.
 \donttest{
 rawSampleURL <- constructWQPURL('USGS-01594440','01075', '', '')
 
-rawSample <- importWQP(rawSampleURL)
+if(!httr::http_error(rawSampleURL)){
+  rawSample <- importWQP(rawSampleURL)
+}
 
 rawSampleURL_NoZip <- constructWQPURL('USGS-01594440','01075', '', '', zip=FALSE)
-rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
-
+if(!httr::http_error(rawSampleURL_NoZip)){
+  rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
+}
+#' 
 STORETex <- constructWQPURL('WIDNR_WQX-10032762','Specific conductance', '', '')
-STORETdata <- importWQP(STORETex)
+if(!httr::http_error(STORETex)){
+  STORETdata <- importWQP(STORETex)
+}
 }
 }
 \seealso{

--- a/man/importWQP.Rd
+++ b/man/importWQP.Rd
@@ -32,20 +32,17 @@ Imports data from the Water Quality Portal based on a specified url.
 \donttest{
 rawSampleURL <- constructWQPURL('USGS-01594440','01075', '', '')
 
-if(!httr::http_error(rawSampleURL)){
-  rawSample <- importWQP(rawSampleURL)
-}
+rawSample <- importWQP(rawSampleURL)
 
 rawSampleURL_NoZip <- constructWQPURL('USGS-01594440','01075', '', '', zip=FALSE)
-if(!httr::http_error(rawSampleURL_NoZip)){
-  rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
-}
-#' 
+
+rawSample2 <- importWQP(rawSampleURL_NoZip, zip=FALSE)
+
 STORETex <- constructWQPURL('WIDNR_WQX-10032762','Specific conductance', '', '')
-if(!httr::http_error(STORETex)){
-  STORETdata <- importWQP(STORETex)
+
+ STORETdata <- importWQP(STORETex)
 }
-}
+
 }
 \seealso{
 \code{\link{readWQPdata}}, \code{\link{readWQPqw}}, \code{\link{whatWQPsites}}

--- a/man/importWaterML2.Rd
+++ b/man/importWaterML2.Rd
@@ -28,6 +28,8 @@ URL <- paste(baseURL, "sites=01646500",
      "statCd=00003",
      "parameterCd=00060",sep="&")
 \donttest{
-timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
+if(!httr::http_error(URL)){
+  timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
 } 
+}
 }

--- a/man/importWaterML2.Rd
+++ b/man/importWaterML2.Rd
@@ -28,8 +28,8 @@ URL <- paste(baseURL, "sites=01646500",
      "statCd=00003",
      "parameterCd=00060",sep="&")
 \donttest{
-if(!httr::http_error(URL)){
-  timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
-} 
+
+timesereies <- importWaterML2(URL, asDateTime=TRUE, tz="UTC")
+ 
 }
 }

--- a/man/readNGWMNsites.Rd
+++ b/man/readNGWMNsites.Rd
@@ -24,17 +24,13 @@ Retrieve site data from the National Ground Water Monitoring Network \url{https:
 }
 \examples{
 \donttest{
-#one site
-if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
-  site <- "USGS.430427089284901"
-  oneSite <- readNGWMNsites(siteNumbers = site)   
-}
+#one site 
+site <- "USGS.430427089284901"
+oneSite <- readNGWMNsites(siteNumbers = site)   
 
- 
 #non-USGS site
-if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
-  site <- "MBMG.103306"
-  siteInfo <- readNGWMNsites(siteNumbers = site)
-}
+site <- "MBMG.103306"
+siteInfo <- readNGWMNsites(siteNumbers = site)
+
 }
 }

--- a/man/readNGWMNsites.Rd
+++ b/man/readNGWMNsites.Rd
@@ -25,12 +25,16 @@ Retrieve site data from the National Ground Water Monitoring Network \url{https:
 \examples{
 \donttest{
 #one site
-site <- "USGS.430427089284901"
-oneSite <- readNGWMNsites(siteNumbers = site)
+if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
+  site <- "USGS.430427089284901"
+  oneSite <- readNGWMNsites(siteNumbers = site)   
+}
 
+ 
 #non-USGS site
-site <- "MBMG.103306"
-siteInfo <- readNGWMNsites(siteNumbers = site)
-
+if(!httr::http_error("https://cida.usgs.gov/ngwmn_cache")){
+  site <- "MBMG.103306"
+  siteInfo <- readNGWMNsites(siteNumbers = site)
+}
 }
 }

--- a/man/readNWISdata.Rd
+++ b/man/readNWISdata.Rd
@@ -67,7 +67,7 @@ See examples below for ideas of constructing queries.
 \examples{
 \donttest{
 # Examples not run for time considerations
-if(!httr::http_error("https://waterservices.usgs.gov")){
+
 dataTemp <- readNWISdata(stateCd="OH",parameterCd="00010", service="dv")
 instFlow <- readNWISdata(sites="05114000", service="iv", 
                    parameterCd="00060", 
@@ -128,10 +128,7 @@ dailyStaffordVA <- readNWISdata(stateCd = "Virginia",
 va_counties <- c("51001","51003","51005","51007","51009","51011","51013","51015")
 va_counties_data <- readNWISdata(startDate = "2015-01-01", endDate = "2015-12-31", 
 parameterCd = "00060", countycode = va_counties)
-}
-
-
-if(!httr::http_error("https://nwis.waterdata.usgs.gov")){
+ 
 site_id <- '01594440'
 rating_curve <- readNWISdata(service = "rating", site_no = site_id, file_type="base")
 all_sites_base <- readNWISdata(service = "rating", file_type="base")
@@ -143,7 +140,7 @@ peak_data <- readNWISdata(service = "peak",
                           site_no = c("01594440","040851325"),
                           range_selection = "data_range")
 
-}
+
 }
 }
 \seealso{

--- a/man/readNWISdata.Rd
+++ b/man/readNWISdata.Rd
@@ -67,6 +67,7 @@ See examples below for ideas of constructing queries.
 \examples{
 \donttest{
 # Examples not run for time considerations
+if(!httr::http_error("https://waterservices.usgs.gov")){
 dataTemp <- readNWISdata(stateCd="OH",parameterCd="00010", service="dv")
 instFlow <- readNWISdata(sites="05114000", service="iv", 
                    parameterCd="00060", 
@@ -87,32 +88,35 @@ bBoxEx <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010")
 
 startDate <- as.Date("2013-10-01")
 endDate <- as.Date("2014-09-30")
-waterYear <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010", 
+waterYear <- readNWISdata(bBox=c(-83,36.5,-82.5,36.75), parameterCd="00010", 
                   service="dv", startDate=startDate, endDate=endDate)
 siteInfo <- readNWISdata(stateCd="WI", parameterCd="00010",
                   hasDataTypeCd="iv", service="site")
-temp <- readNWISdata(bBox=c(-83,36.5,-81,38.5), parameterCd="00010", service="site", 
+temp <- readNWISdata(bBox=c(-83,36.5,-82.5,36.75), parameterCd="00010", service="site", 
                    seriesCatalogOutput=TRUE)
-wiGWL <- readNWISdata(stateCd="WI",service="gwlevels")
-meas <- readNWISdata(state_cd="WI",service="measurements",format="rdb_expanded")
+wiGWL <- readNWISdata(stateCd = "WI", service = "gwlevels")
+meas <- readNWISdata(state_cd = "WI", service = "measurements",
+                     format = "rdb_expanded")
 
-waterYearStat <- readNWISdata(site=c("01646500"),service="stat",statReportType="annual",
-                 statYearType="water", missingData="on")
+waterYearStat <- readNWISdata(site = c("01646500"), 
+                              service = "stat",
+                              statReportType="annual",
+                              statYearType = "water",
+                              missingData = "on")
 monthlyStat <- readNWISdata(site=c("01646500"),
                             service="stat",
-                            statReportType="monthly")                                   
-dailyStat <- readNWISdata(site=c("01646500"),
-                          service="stat",
-                          statReportType="daily",
-                          statType=c("p25","p50","p75","min","max"),
-                          parameterCd="00060")
+                            statReportType="monthly")  
+                                                             
+dailyStat <- readNWISdata(site = c("01646500"),
+                          service = "stat",
+                          statReportType = "daily",
+                          statType = c("p25","p50","p75","min","max"),
+                          parameterCd = "00060")
 
-dailyRI <- readNWISdata(stateCd = "Rhode Island", parameterCd = "00060")
-
-arg.list <- list(site="03111548",
-                 statReportType="daily",
-                 statType=c("p25","p50","p75","min","max"),
-                 parameterCd="00060")
+arg.list <- list(site = "03111548",
+                 statReportType = "daily",
+                 statType = c("p25","p50","p75","min","max"),
+                 parameterCd = "00060")
 allDailyStats_2 <- readNWISdata(arg.list, service="stat")
 
 #' # use county names to get data
@@ -124,20 +128,22 @@ dailyStaffordVA <- readNWISdata(stateCd = "Virginia",
 va_counties <- c("51001","51003","51005","51007","51009","51011","51013","51015")
 va_counties_data <- readNWISdata(startDate = "2015-01-01", endDate = "2015-12-31", 
 parameterCd = "00060", countycode = va_counties)
+}
+
+
+if(!httr::http_error("https://nwis.waterdata.usgs.gov")){
 site_id <- '01594440'
 rating_curve <- readNWISdata(service = "rating", site_no = site_id, file_type="base")
 all_sites_base <- readNWISdata(service = "rating", file_type="base")
 all_sites_core <- readNWISdata(service = "rating", file_type="corr")
 all_sites_exsa <- readNWISdata(service = "rating", file_type="exsa")
 all_sites_24hrs <- readNWISdata(service = "rating", file_type="exsa", period = 24)
-
-today <- readNWISdata(service="iv", startDate = Sys.Date(), 
-                      parameterCd = "00060", siteNumber = "05114000")
                       
 peak_data <- readNWISdata(service = "peak", 
                           site_no = c("01594440","040851325"),
                           range_selection = "data_range")
 
+}
 }
 }
 \seealso{

--- a/man/readNWISpCode.Rd
+++ b/man/readNWISpCode.Rd
@@ -27,6 +27,11 @@ parameterData data frame with the following information:
 Imports data from NWIS about meaured parameter based on user-supplied parameter code or codes.
 This function gets the data from here: \url{https://nwis.waterdata.usgs.gov/nwis/pmcodes}
 }
+\examples{
+
+paramINFO <- readNWISpCode(c('01075','00060','00931'))
+paramINFO <- readNWISpCode(c('01075','00060','00931', NA))
+}
 \seealso{
 \code{\link{importRDB1}}
 }

--- a/man/readNWISpCode.Rd
+++ b/man/readNWISpCode.Rd
@@ -27,10 +27,6 @@ parameterData data frame with the following information:
 Imports data from NWIS about meaured parameter based on user-supplied parameter code or codes.
 This function gets the data from here: \url{https://nwis.waterdata.usgs.gov/nwis/pmcodes}
 }
-\examples{
-paramINFO <- readNWISpCode(c('01075','00060','00931'))
-paramINFO <- readNWISpCode(c('01075','00060','00931', NA))
-}
 \seealso{
 \code{\link{importRDB1}}
 }

--- a/man/readNWISsite.Rd
+++ b/man/readNWISsite.Rd
@@ -70,8 +70,10 @@ Imports data from USGS site file site. This function gets data from here: \url{h
 }
 \examples{
 \donttest{
+try({
 siteINFO <- readNWISsite('05114000')
 siteINFOMulti <- readNWISsite(c('05114000','09423350'))
+})
 }
 }
 \keyword{USGS}

--- a/man/readNWISsite.Rd
+++ b/man/readNWISsite.Rd
@@ -70,10 +70,10 @@ Imports data from USGS site file site. This function gets data from here: \url{h
 }
 \examples{
 \donttest{
-try({
+
 siteINFO <- readNWISsite('05114000')
 siteINFOMulti <- readNWISsite(c('05114000','09423350'))
-})
+
 }
 }
 \keyword{USGS}

--- a/man/readNWISuv.Rd
+++ b/man/readNWISuv.Rd
@@ -65,6 +65,7 @@ parameterCd <- '00060'
 startDate <- "2014-10-10"
 endDate <- "2014-10-10"
 \donttest{
+try({
 rawData <- readNWISuv(site_id,parameterCd,startDate,endDate)
 
 rawData_today <- readNWISuv(site_id, parameterCd, Sys.Date(),Sys.Date())
@@ -79,8 +80,8 @@ centralTime <- readNWISuv(site_id,parameterCd,
 # Adding 'Z' to the time indicates to the web service to call the data with UTC time:
 GMTdata <- readNWISuv(site_id,parameterCd,
                            "2014-10-10T00:00Z", "2014-10-10T23:59Z")
+})
 }
-
 }
 \seealso{
 \code{\link{renameNWISColumns}}, \code{\link{importWaterML1}}

--- a/man/readNWISuv.Rd
+++ b/man/readNWISuv.Rd
@@ -65,7 +65,7 @@ parameterCd <- '00060'
 startDate <- "2014-10-10"
 endDate <- "2014-10-10"
 \donttest{
-try({
+
 rawData <- readNWISuv(site_id,parameterCd,startDate,endDate)
 
 rawData_today <- readNWISuv(site_id, parameterCd, Sys.Date(),Sys.Date())
@@ -80,7 +80,7 @@ centralTime <- readNWISuv(site_id,parameterCd,
 # Adding 'Z' to the time indicates to the web service to call the data with UTC time:
 GMTdata <- readNWISuv(site_id,parameterCd,
                            "2014-10-10T00:00Z", "2014-10-10T23:59Z")
-})
+
 }
 }
 \seealso{

--- a/man/whatNWISdata.Rd
+++ b/man/whatNWISdata.Rd
@@ -61,6 +61,7 @@ for more information.
 }
 \examples{
 \donttest{
+try({
 availableData <- whatNWISdata(siteNumber = '05114000')
 # To find just unit value ('instantaneous') data:
 uvData <- whatNWISdata(siteNumber = '05114000',service="uv")
@@ -68,6 +69,7 @@ uvDataMulti <- whatNWISdata(siteNumber = c('05114000','09423350'),service=c("uv"
 flowAndTemp <- whatNWISdata(stateCd = "WI", service = "uv", 
                              parameterCd = c("00060","00010"),
                              statCd = "00003")
+})
 }
 }
 \keyword{USGS}

--- a/man/whatNWISdata.Rd
+++ b/man/whatNWISdata.Rd
@@ -61,7 +61,7 @@ for more information.
 }
 \examples{
 \donttest{
-try({
+
 availableData <- whatNWISdata(siteNumber = '05114000')
 # To find just unit value ('instantaneous') data:
 uvData <- whatNWISdata(siteNumber = '05114000',service="uv")
@@ -69,7 +69,7 @@ uvDataMulti <- whatNWISdata(siteNumber = c('05114000','09423350'),service=c("uv"
 flowAndTemp <- whatNWISdata(stateCd = "WI", service = "uv", 
                              parameterCd = c("00060","00010"),
                              statCd = "00003")
-})
+
 }
 }
 \keyword{USGS}

--- a/man/whatNWISsites.Rd
+++ b/man/whatNWISsites.Rd
@@ -36,9 +36,9 @@ Mapper format is used
 }
 \examples{
 \donttest{
-try({
+
 siteListPhos <- whatNWISsites(stateCd="OH",parameterCd="00665")
 oneSite <- whatNWISsites(sites="05114000")
-})
+
 }
 }

--- a/man/whatNWISsites.Rd
+++ b/man/whatNWISsites.Rd
@@ -36,7 +36,9 @@ Mapper format is used
 }
 \examples{
 \donttest{
+try({
 siteListPhos <- whatNWISsites(stateCd="OH",parameterCd="00665")
 oneSite <- whatNWISsites(sites="05114000")
+})
 }
 }

--- a/man/wqpSpecials.Rd
+++ b/man/wqpSpecials.Rd
@@ -73,12 +73,12 @@ The \code{readWQPsummary} function has
 }
 \examples{
 \donttest{
-try({
+
 site1 <- whatWQPsamples(siteid="USGS-01594440")
 
 type <- "Stream"
 sites <- whatWQPsamples(countycode="US:55:025",siteType=type)
-})
+
 }
 \donttest{
 
@@ -87,14 +87,14 @@ sites <- whatWQPmetrics(countycode="US:55:025",siteType=type)
 lakeSites <- whatWQPmetrics(siteType = "Lake, Reservoir, Impoundment", statecode = "US:55")
 }
 \donttest{
-try({
+
 site1 <- whatWQPsites(siteid="USGS-01594440")
 
 type <- "Stream"
 sites <- whatWQPsites(countycode="US:55:025",
                       characteristicName = "Phosphorus",
                       siteType=type)
-})
+
 }
 \donttest{
 site1 <- readWQPsummary(siteid="USGS-07144100",

--- a/man/wqpSpecials.Rd
+++ b/man/wqpSpecials.Rd
@@ -73,10 +73,12 @@ The \code{readWQPsummary} function has
 }
 \examples{
 \donttest{
+try({
 site1 <- whatWQPsamples(siteid="USGS-01594440")
 
 type <- "Stream"
 sites <- whatWQPsamples(countycode="US:55:025",siteType=type)
+})
 }
 \donttest{
 
@@ -85,12 +87,14 @@ sites <- whatWQPmetrics(countycode="US:55:025",siteType=type)
 lakeSites <- whatWQPmetrics(siteType = "Lake, Reservoir, Impoundment", statecode = "US:55")
 }
 \donttest{
+try({
 site1 <- whatWQPsites(siteid="USGS-01594440")
 
 type <- "Stream"
 sites <- whatWQPsites(countycode="US:55:025",
                       characteristicName = "Phosphorus",
                       siteType=type)
+})
 }
 \donttest{
 site1 <- readWQPsummary(siteid="USGS-07144100",

--- a/tests/testthat/tests_general.R
+++ b/tests/testthat/tests_general.R
@@ -375,8 +375,8 @@ test_that("400 errors return a verbose error", {
   
   url <- "https://waterservices.usgs.gov/nwis/site/?stateCd=IA&bBox=-92.821445,42.303044,-92.167168,42.646524&format=mapper"
 
-  expect_error(getWebServiceData(url))
-  expect_equal(tryCatch(getWebServiceData(url), error = function(e) e$message), "HTTP Status 400 - syntactic error: Only one Major filter can be supplied. Found [bbox] and [stateCd]. Please remove the extra major filter[s].")
+  expect_message(getWebServiceData(url))
+  expect_equal(tryCatch(getWebServiceData(url), message = function(e) e$message)[1], "Request failed [400]. Retrying in 1 seconds...\n")
   
 })
 

--- a/tests/testthat/tests_general.R
+++ b/tests/testthat/tests_general.R
@@ -376,8 +376,7 @@ test_that("400 errors return a verbose error", {
   url <- "https://waterservices.usgs.gov/nwis/site/?stateCd=IA&bBox=-92.821445,42.303044,-92.167168,42.646524&format=mapper"
 
   expect_message(getWebServiceData(url))
-  expect_equal(tryCatch(getWebServiceData(url), message = function(e) e$message)[1], "Request failed [400]. Retrying in 1 seconds...\n")
-  
+ 
 })
 
 test_that("internal functions",{

--- a/tests/testthat/tests_imports.R
+++ b/tests/testthat/tests_imports.R
@@ -43,7 +43,7 @@ test_that("External importRDB1 tests", {
                           format="tsv",
                           statCd = "laksjd")
   # And....now there's data there:
-  expect_error(importRDB1(url))
+  expect_null(importRDB1(url))
 })
 
 context("importRDB")

--- a/tests/testthat/tests_imports.R
+++ b/tests/testthat/tests_imports.R
@@ -130,7 +130,7 @@ test_that("External importWaterML1 test", {
   url <- constructNWISURL("05212700", "00060", "2014-01-01", "2014-01-10",'dv', statCd = "00001")
   noData <- importWaterML1(url) 
   expect_true(class(attr(noData,"url"))=="character")
-  expect_true(all(dim(noData)==0))
+  expect_true(all(dim(noData) == c(0, 4)))
   
   url <- constructNWISURL(service = 'iv', site = c('02319300','02171500'), 
                           startDate = "2015-04-04", endDate = "2015-04-05")


### PR DESCRIPTION
We've been pinged for not failing gracefully on our examples in CRAN (this is the 2nd time). CRAN doesn't want the functions to `stop` or `error` if the server returns an error message. So...I switched the `getWebService` function to use `httr::message_for_status` (instead of `httr::stop_for_status`), and return a `NULL`. This is consistent with what @dblodgett-usgs  is doing with `sbtools`.

@wdwatkins or @dblodgett-usgs ...if one of you could glance at the code to see if it looks good to you, that would be great. I actually got to test it quite extensively yesterday because WQP was failing all over the place (someone was overloading them).

We need to resubmit to CRAN in the next couple of days to avoid having it taken down.

