### PR TITLE
quote handling -- fixes #583

### DIFF
--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -23,7 +23,8 @@ find_good_names = function(input, type) {
   if (type == "nav") {
     grep("comid", names(input), value = TRUE)
   } else if (type == "feature") {
-    c("sourceName", "identifier", "comid")
+    c("sourceName", "identifier", "comid",
+      names(input)[names(input) %in% c("name", "reachcode", "measure")])
   } else {
     NULL
   }

--- a/R/importRDB1.r
+++ b/R/importRDB1.r
@@ -135,6 +135,7 @@ importRDB1 <- function(obs_url, asDateTime=TRUE, convertType = TRUE, tz="UTC"){
   if(data.rows > 0){
     args_list <- list(file = f,
                  delim = "\t",
+                 quote = "",
                  skip = meta.rows + 2,
                  col_names = FALSE)
     if(utils::packageVersion("readr") > 1.4){

--- a/tests/testthat/tests_imports.R
+++ b/tests/testthat/tests_imports.R
@@ -44,6 +44,24 @@ test_that("External importRDB1 tests", {
                           statCd = "laksjd")
   # And....now there's data there:
   expect_null(importRDB1(url))
+  
+  site <- "11486500"
+  
+  url <- dataRetrieval:::drURL("site", arg.list = list(siteOutput = "Expanded", 
+                                                       format = "rdb", 
+                                                       site = site))
+  site_data <- importRDB1(url)
+  
+  expect_equal(site_data$station_nm, "\"G\" CANAL NEAR OLENE,OREG.")
+  
+  site <- "040854588204"
+  
+  url <- dataRetrieval:::drURL("site", arg.list = list(siteOutput = "Expanded", 
+                                                       format = "rdb", 
+                                                       site = site))
+  site_data <- importRDB1(url)
+  
+  expect_equal(site_data$station_nm, "\"FISHER CR AT 32 & HIGHLAND RD AT HOWARDS GROVE, W")
 })
 
 context("importRDB")

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -15,7 +15,8 @@ test_that("NLDI starting sources...", {
   # POINT GEOMETERY
   expect_equal(sum(names(findNLDI(nwis = '11120000')) ==
                      c('sourceName', 'identifier', "comid",
-                       "X", "Y", "geometry")),  6)
+                       "name", "reachcode", "measure",
+                       "X", "Y", "geometry")),  9)
   # COMID
   expect_equal(findNLDI(comid = 101)$sourceName, "NHDPlus comid")
   # NWIS


### PR DESCRIPTION
I found a site in Wisconsin as noted in #583 with the name `"FISHER CR AT 32 & HIGHLAND RD AT HOWARDS GROVE, W`

That was breaking the readr parsing without specifying no quotes. I've run this over the whole site file and it seems to work fine. I would not be surprised to find out that there _are_ quotes used as string quotes some place, but the tab separator seems to preclude the need for them? Unless there are tabs in the strings too -- Someone totally but a \t in a string in nwis some place... 