### PR TITLE
Adapting NLDI client to changes in the NLDI service

### DIFF
--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -104,8 +104,12 @@ get_nldi = function(url, type = "", use_sf = FALSE) {
       
       tmp <- tryCatch({
         sf::read_sf(d) }, 
-      error   = function(e){ NULL },
-      warning = function(w){ NULL }
+      error   = function(e){ 
+        message("No data found for: ", basename(url))
+        return(NULL)},
+      warning = function(w){  
+        message("No data found for: ", basename(url))
+        return(NULL) }
       )
         
       good_name = find_good_names(tmp, type)
@@ -191,6 +195,7 @@ clean_nwis_ids = function(tmp) {
 #' \donttest{
 #' valid_ask(all = get_nldi_sources(), "nwis")
 #' }
+
 valid_ask = function(all, type) {
   # those where the requested pattern is included in a nldi_source ...
   # means we will catch nwis - not just nwissite ...
@@ -285,6 +290,7 @@ valid_ask = function(all, type) {
 #' ## Limit search to 50 km
 #'  findNLDI(comid = 101, nav = "DM", find = c("nwis", "wqp", "flowlines"), distance_km = 50)
 #'}
+
 findNLDI <- function(comid = NULL,
                      nwis = NULL,
                      wqp = NULL,

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -1,6 +1,6 @@
 context("NLDI...")
 
-test_that("NLDI offerings...", {
+test_that("NLDI messageing NULL", {
   skip_on_cran()
   xx = findNLDI(wqp = "TCEQMAIN-10016",
                 nav = "UM",
@@ -37,10 +37,10 @@ test_that("NLDI starting sources...", {
   expect_equal(sum(names(findNLDI(comid = 101)) %in%
                      c('sourceName', 'identifier', "comid", "geometry")),  4)
   # POINT GEOMETERY
-  expect_equal(sum(names(findNLDI(nwis = '11120000')) ==
+  expect_true(all(names(findNLDI(nwis = '11120000')) %in%
                      c('sourceName', 'identifier', "comid",
                        "name", "reachcode", "measure",
-                       "X", "Y", "geometry")),  9)
+                       "X", "Y", "geometry")))
   # COMID
   expect_equal(findNLDI(comid = 101)$sourceName, "NHDPlus comid")
   # NWIS
@@ -76,17 +76,16 @@ test_that("NLDI navigation sources...", {
   # ERRORS: Bad NAV REQUEST
   expect_error(findNLDI(nwis = '11120000', nav = c("DT")))
   expect_error(findNLDI(nwis = '11120000', nav = c("DT", "UM")))
-  # MESSAGE: Data not found
-  expect_message(findNLDI(comid = 101, nav = "UM", find = "nwis"))
+  # WARNING: Data not found
+  expect_warning(findNLDI(comid = 101, nav = "UM", find = "nwis"))
 })
 
 test_that("NLDI find sources...", {
 
   skip_on_cran()
 
-  expect_equal(length(findNLDI(nwis = '11120000', nav = "UT", find = "wade")),2)
-  expect_equal(length(findNLDI(nwis = '11120000', nav = "UT", find = c("nwis", "wqp"))), 3)
-  expect_equal(length(findNLDI(nwis = '11120000', nav = c("UT", "UM"), find = c("nwis", "wqp", "flowlines"))), 7)
+  expect_equal(length(findNLDI(nwis = '11120000', nav = "UT", find = "wade")), 2)
+  expect_equal(length(findNLDI(nwis = '11120000', nav = c("UT", "UM"), find = c("nwis", "wade", "flowlines"))), 6)
 })
 
 test_that("sf not installed...", {

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -2,8 +2,28 @@ context("NLDI...")
 
 test_that("NLDI offerings...", {
   skip_on_cran()
+  xx = findNLDI(wqp = "TCEQMAIN-10016",
+                nav = "UM",
+                find = "nwissite",
+                distance_km = 2,
+                no_sf = FALSE)
+  
+  expect_true(nrow(xx) == 1)
+})
+
+
+test_that("NLDI offerings...", {
+  skip_on_cran()
   expect_true(nrow(get_nldi_sources()) > 1)
 })
+
+
+xx = findNLDI(wqp = "TCEQMAIN-10016",
+              nav = "UM",
+              find = "nwissite",
+              distance_km = 2,
+              no_sf = FALSE)
+
 
 test_that("NLDI starting sources...", {
 

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -5,8 +5,12 @@ test_that("NLDI offerings...", {
   xx = findNLDI(wqp = "TCEQMAIN-10016",
                 nav = "UM",
                 find = "nwissite",
-                distance_km = 2,
-                no_sf = FALSE)
+                distance_km = 2)
+  
+  expect_message(findNLDI(wqp = "TCEQMAIN-10016",
+                               nav = "UM",
+                               find = "nwissite",
+                               distance_km = 2))
   
   expect_true(nrow(xx) == 1)
 })


### PR DESCRIPTION
Hi @ldecicco-USGS,

This PR modifies the `findNLDI` function to handle two changes in the NLDI response. 

The first was raised in #623 and relates to requests that return no data. The behavior now is a more clear warning message that no data was found rather then the crypitc `jsonlite`/`sf` error message.

The second was a change in the NLDI that defaulted to HTML landing pages (raised in internetofwater/nldi-services#315). The behavior now is that a JSON object is explicitly requested in the URLs constructed in `findNLDI` (opposed to relying on a default).

All tests pass locally as well. Please let me know if anything else needs changing!

Mike 
