### PR TITLE
Syntax fix to cell "getSiteExtended" in dataRetrieval.Rmd

### DIFF
--- a/vignettes/dataRetrieval.Rmd
+++ b/vignettes/dataRetrieval.Rmd
@@ -224,7 +224,7 @@ In the following example, we limit the retrieved data to only daily data. The de
 # Continuing from the previous example:
 # This pulls out just the daily, mean data:
 
-dailyDataAvailable <- whatNWISdata(siteNumbers,
+dailyDataAvailable <- whatNWISdata(siteNumber=siteNumbers,
                     service="dv", statCd="00003")
 
 


### PR DESCRIPTION
Small PR to make a syntax fix to the vignette associated with `dataRetrieval.Rmd`.

The cell “getSiteExtended” is currently written as:

```{r getSiteExtended, echo=TRUE, eval=FALSE}
# Continuing from the previous example:
# This pulls out just the daily, mean data:

dailyDataAvailable <- whatNWISdata(siteNumbers,
                    service="dv", statCd="00003")


```

And produces the following error:

```
Error: All components of query must be named
```

Instead, the `siteNumber` keyword parameter should be supplied to the function call:

```{r getSiteExtended, echo=TRUE, eval=FALSE}
# Continuing from the previous example:
# This pulls out just the daily, mean data:

dailyDataAvailable <- whatNWISdata(siteNumber=siteNumbers,
                    service="dv", statCd="00003")


```

This fixes the problem and is the only proposed change in this PR.