### PR TITLE
GitHub Actions to Automatically Style and Lint PRs

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -4,7 +4,7 @@
 on:
   pull_request:
     paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
-    branches= [main]
+    branches: [main]
 
 name: Style and Lint
 

--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -1,0 +1,88 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Only run when PR is opened to the main branch, and changes are made to these types of R files
+on:
+  pull_request:
+    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
+    branches= [main]
+
+name: Style and Lint
+
+jobs:
+  # First run styler and push style changes to feature branch
+  style:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::styler
+          needs: styler
+
+      - name: Enable styler cache
+        run: styler::cache_activate()
+        shell: Rscript {0}
+
+      - name: Determine cache location
+        id: styler-location
+        run: |
+          cat(
+            "##[set-output name=location;]",
+            styler::cache_info(format = "tabular")$location,
+            "\n",
+            sep = ""
+          )
+        shell: Rscript {0}
+
+      - name: Cache styler
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.styler-location.outputs.location }}
+          key: ${{ runner.os }}-styler-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-styler-
+            ${{ runner.os }}-
+
+      - name: Run styler on all files containing R code
+        run: styler::style_pkg(filetype = c(".R", ".Rmd", ".Rmarkdown", ".Rnw"))
+        shell: Rscript {0}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add R/\*
+          git commit -m "Style code" || echo "No changes to commit"
+          git pull --ff-only
+          git push origin
+  # Next run lintr to annotate the PR with anything caught by the linter that wasn't changed by styler
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install lintr
+        run: install.packages("lintr")
+        shell: Rscript {0}
+
+      - name: Run lintr on the package
+        run: lintr::lint_package()
+        shell: Rscript {0}

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,6 @@
+linters: linters_with_defaults(
+    object_name_linter=NULL,
+    line_length_linter=NULL,
+    cyclocomp_linter=NULL
+   ) # see vignette("lintr")
+encoding: "UTF-8"


### PR DESCRIPTION
## Thought Process and Summary
I've thought a bit about how to best accomplish some standard styling and linting for this package. After exploring a few different avenues, I think what makes the most sense is to have a GitHub Action that does the following:

1. Automatically style feature branches (using `styler`) when pull requests are opened by pushing a commit to the feature branch itself. This eases the burden on contributors styling their own code either while writing it or by running `styler` locally, and ensures consistent style as new contributions are made. This strategy also avoids automated style commits from being made directly on the `main` branch, which seems wise just in-case the style changes do something unexpected.
2. Run `lintr` after styling the code and annotate the GitHub Action associated with the pull request. The linter captures some things that are not strictly code style, such as instances when variables are assigned and not used. Again, by doing this to the feature branch in the PR, changes can be caught and considered prior to merging into `main`

## This PR
This PR establishes a `.lintr` style file which controls some aspects of the linting. In particular, we are not enforcing the following through the linter:
- any object naming conventions
- line length limits
- cyclomatic complexity as this package handles many unique cases and data streams

This PR also establishes a new GitHub Actions `.yaml` file called `style-and-lint.yaml` which is run when a PR is opened to the main branch and involves changes to files containing R code. This action does the processes summarized above:
- First it automatically applies `styler` to style the feature branch code via an automated commit
- Then it runs `lintr`, providing annotations of output from the linter

## Impact of automatic styling
The first run of the automated styling is going to impact a __lot__ of code. I've run the styler locally on the repository and pushed it up to my branch [using-lintr](https://github.com/elbeejay/dataRetrieval/tree/using-lintr) so a diff can be compared between that feature branch and the current `main` branch if desired. I've looked through some of the diff, and the changes are, as far as I can tell, entirely cosmetic and involve spacing, " vs ' quotes, and things of that nature. I ran `lintr` locally on the stylized package as well and got a handful of suggestions that fell into the following categories:
- "object_usage_linter": local variable assignment where the variable is not obviously being used in the code
- "vector_logic_linter": where && and || are suggested as alternatives to & and |
- "seq_linter": where the use of `1:nrow(...)` apparently can fail in empty edge cases, so they suggest `seq_len(ncol(...))`
- "commented_code_linter": suggests the removal of lines of code that have been commented out

**I did not take any action to address any of those linter suggestions** because I suspect the choices made in `dataRetrieval` are often deliberately made. I think making any of those changes would require some extra care, which I view as beyond the scope of this simple automated styling and linting PR. 

---
I'm of course open to discussion and altering this approach. Some alternative processes I considered and dismissed were:
- After any push to `main` automatically style the code before the package is built (seemed risky if things broke for whatever reason after styling)
- Could lint the PR without automated styling (as is, there are far too many linter suggestions for this to be useful)
