### PR TITLE
Fix to styler push auto-commit

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -60,13 +60,10 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add R/\*
-          git commit -m "Style code" || echo "No changes to commit"
-          git pull --ff-only
-          git push origin
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Style Code
+
   # Next run lintr to annotate the PR with anything caught by the linter that wasn't changed by styler
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix the GitHub Actions workflow to properly push the changes made by styler. For an example of this in action, see [this PR](https://github.com/elbeejay/dataRetrieval/pull/1) I opened between two branches on my fork. The automatic commit gets the message "Style Code" and is coauthored by the person opening the PR and the actions bot ([the commit itself](https://github.com/elbeejay/dataRetrieval/pull/1/commits/f9ff977db7ebbf7fc1324ef7dae812324bd70083)) The successful Actions workflow run is also viewable [here](https://github.com/elbeejay/dataRetrieval/actions/runs/3235922017/jobs/5301011488).