### PR TITLE
Fix return structure, bug in url constructor, test, and add warn flag…

### DIFF
--- a/man/findNLDI.Rd
+++ b/man/findNLDI.Rd
@@ -14,7 +14,8 @@ findNLDI(
   nav = NULL,
   find = c("flowlines"),
   distance_km = 100,
-  no_sf = FALSE
+  no_sf = FALSE,
+  warn = TRUE
 )
 }
 \arguments{
@@ -49,6 +50,8 @@ kilometers (default = 100)}
 
 \item{no_sf}{if available, should `sf` be used for parsing,
 defaults to `TRUE` if `sf` is locally installed}
+
+\item{warn}{(default TRUE) should warnings be printed}
 }
 \value{
 a list of data.frames if sf is not installed, a list of sf objects if it is

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -6,14 +6,16 @@ test_that("NLDI messageing NULL", {
     wqp = "TCEQMAIN-10016",
     nav = "UM",
     find = "nwissite",
-    distance_km = 2
+    distance_km = 2,
+    warn = FALSE
   )
 
   expect_warning(findNLDI(
     wqp = "TCEQMAIN-10016",
     nav = "UM",
     find = "nwissite",
-    distance_km = 2
+    distance_km = 2, 
+    warn = TRUE
   ))
 
   expect_true(class(xx) == "list")
@@ -32,7 +34,8 @@ xx <- findNLDI(
   nav = "UM",
   find = "nwissite",
   distance_km = 2,
-  no_sf = FALSE
+  no_sf = FALSE,
+  warn = FALSE
 )
 
 
@@ -40,82 +43,82 @@ test_that("NLDI starting sources...", {
   skip_on_cran()
 
   # LINESTRING GEOMETERY
-  expect_equal(sum(names(findNLDI(comid = 101)$origin) %in%
+  expect_equal(sum(names(findNLDI(comid = 101, warn = FALSE)$origin) %in%
     c("sourceName", "identifier", "comid", "geometry")), 4)
   # POINT GEOMETERY
-  expect_true(all(names(findNLDI(nwis = "11120000")$origin) %in%
+  expect_true(all(names(findNLDI(nwis = "11120000", warn = FALSE)$origin) %in%
     c(
       "sourceName", "identifier", "comid",
       "name", "reachcode", "measure",
       "X", "Y", "geometry"
     )))
   # COMID
-  expect_equal(findNLDI(comid = 101)$origin$sourceName, "NHDPlus comid")
+  expect_equal(findNLDI(comid = 101, warn = FALSE)$origin$sourceName, "NHDPlus comid")
   # NWIS
-  expect_equal(findNLDI(nwis = "11120000")$origin$sourceName, "NWIS Surface Water Sites")
+  expect_equal(findNLDI(nwis = "11120000", warn = FALSE)$origin$sourceName, "NWIS Surface Water Sites")
   # WQP
-  expect_equal(findNLDI(wqp = "USGS-04024315")$origin$sourceName, "Water Quality Portal")
+  expect_equal(findNLDI(wqp = "USGS-04024315", warn = FALSE)$origin$sourceName, "Water Quality Portal")
   # LOCATION
-  expect_equal(findNLDI(location = c(-115, 40))$origin$sourceName, "NHDPlus comid")
+  expect_equal(findNLDI(location = c(-115, 40), warn = FALSE)$origin$sourceName, "NHDPlus comid")
   # ERROR: LOCATION COORDINATES FLIPPED
-  expect_error(findNLDI(location = c(40, -115)))
+  expect_error(findNLDI(location = c(40, -115), warn = FALSE))
   # GENERAL START: STABLE
-  expect_equal(findNLDI(origin = list("comid" = 101))$origin$sourceName, "NHDPlus comid")
+  expect_equal(findNLDI(origin = list("comid" = 101), warn = FALSE)$origin$sourceName, "NHDPlus comid")
   # GENERAL START: NON-STABLE
-  expect_equal(findNLDI(origin = list("wade" = "NMwr_S148023"))$origin$sourceName, "Water Data Exchange 2.0 Sites")
+  expect_equal(findNLDI(origin = list("wade" = "NMwr_S148023"), warn = FALSE)$origin$sourceName, "Water Data Exchange 2.0 Sites")
   # ERROR: TWO STARTS
-  expect_error(findNLDI(nwis = 1000, comid = 101))
+  expect_error(findNLDI(nwis = 1000, comid = 101, warn = FALSE))
   # NON EXISTING SITE
-  expect_message(findNLDI(comid = 1))
+  expect_message(findNLDI(comid = 1, warn = FALSE))
 })
 
 test_that("NLDI navigation sources...", {
   skip_on_cran()
 
   # UPPER TRIBUTARY
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "UT")$UT_flowlines), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "UT", warn = FALSE)$UT_flowlines), 2)
   # UPPER MAIN
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "UM")$UM_flowlines), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "UM", warn = FALSE)$UM_flowlines), 2)
   # DOWNSTREAM MAIN
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "DM")$DM_flowlines), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "DM", warn = FALSE)$DM_flowlines), 2)
   # MULTI-REQUEST
-  expect_equal(length(findNLDI(nwis = "11120000", nav = c("UT", "UM"))), 3)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = c("UT", "UM"), warn = FALSE)), 3)
   # ERRORS: Bad NAV REQUEST
-  expect_error(findNLDI(nwis = "11120000", nav = c("DT")))
-  expect_error(findNLDI(nwis = "11120000", nav = c("DT", "UM")))
+  expect_error(findNLDI(nwis = "11120000", nav = c("DT"), warn = FALSE))
+  expect_error(findNLDI(nwis = "11120000", nav = c("DT", "UM"), warn = FALSE))
   # WARNING: Data not found
-  expect_warning(findNLDI(comid = 101, nav = "UM", find = "nwis"))
+  expect_warning(findNLDI(comid = 101, nav = "UM", find = "nwis", warn = TRUE))
 })
 
 test_that("NLDI find sources...", {
   skip_on_cran()
 
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "UT", find = "wade")), 2)
-  expect_equal(length(findNLDI(nwis = "11120000", nav = c("UT", "UM"), find = c("nwis", "wade", "flowlines"))), 6)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "UT", find = "wade", warn = FALSE)), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = c("UT", "UM"), find = c("nwis", "wade", "flowlines"), warn = FALSE)), 6)
 })
 
 test_that("sf not installed...", {
   skip_on_cran()
 
-  expect_true(!"geometry" %in% findNLDI(nwis = "11120000", no_sf = TRUE)[[1]])
-  expect_equal(class(findNLDI(nwis = "11120000", nav = "UT", find = c("nwis"), no_sf = TRUE)[[2]]), "data.frame")
-  expect_true(c("X") %in% names(findNLDI(nwis = "11120000", nav = "UT", find = c("nwis"), no_sf = TRUE)[[2]]))
+  expect_true(!"geometry" %in% findNLDI(nwis = "11120000", no_sf = TRUE, warn = FALSE)[[1]])
+  expect_equal(class(findNLDI(nwis = "11120000", nav = "UT", find = c("nwis"), no_sf = TRUE, warn = FALSE)[[2]]), "data.frame")
+  expect_true(c("X") %in% names(findNLDI(nwis = "11120000", nav = "UT", find = c("nwis"), no_sf = TRUE, warn = FALSE)[[2]]))
 })
 
 
 test_that("Distance...", {
   skip_on_cran()
 
-  full <- findNLDI(comid = 101, nav = "UT", find = "nwis", distance_km = 9999)
-  part <- findNLDI(comid = 101, nav = "UT", find = "nwis")
+  full <- findNLDI(comid = 101, nav = "UT", find = "nwis", distance_km = 9999, warn = FALSE)
+  part <- findNLDI(comid = 101, nav = "UT", find = "nwis", warn = FALSE)
   expect_true(nrow(full$UT_nwissite) > nrow(part$UT_nwissite))
 })
 
 test_that("basin", {
   skip_on_cran()
 
-  xx <- findNLDI(comid = 101, nav = "UT", find = "basin")
-  xx2 <- findNLDI(comid = 101, nav = "UT", find = "basin", no_sf = TRUE)
+  xx <- findNLDI(comid = 101, nav = "UT", find = "basin", warn = FALSE)
+  xx2 <- findNLDI(comid = 101, nav = "UT", find = "basin", no_sf = TRUE , warn = FALSE)
   expect_true(sf::st_geometry_type(xx$basin) == "POLYGON")
   expect_equal(ncol(xx2$basin), 0)
 })
@@ -124,8 +127,8 @@ test_that("basin", {
 test_that("ignore flowlines", {
   skip_on_cran()
 
-  xx <- findNLDI(comid = 101, nav = "DM", find = c("nwis", "flowlines"))
-  xx2 <- findNLDI(comid = 101, nav = "DM", find = "nwis")
+  xx <- findNLDI(comid = 101, nav = "DM", find = c("nwis", "flowlines"), warn = FALSE)
+  xx2 <- findNLDI(comid = 101, nav = "DM", find = "nwis", warn = FALSE)
   expect_gt(length(xx), length(xx2))
   expect_true("DM_flowlines" %in% names(xx))
   expect_true(!"DM_flowlines" %in% names(xx2))
@@ -136,8 +139,8 @@ test_that("sf points", {
   skip_on_cran()
   library(sf)
   p2 <- st_sfc(st_point(c(-119.8458, 34.4146)), crs = 4326)
-  expect_equal(findNLDI(location = p2), findNLDI(location = sf::st_as_sf(p2)))
-  expect_error(findNLDI(location = st_buffer(p2, .01)))
+  expect_equal(findNLDI(location = p2, warn = FALSE), findNLDI(location = sf::st_as_sf(p2)))
+  expect_error(findNLDI(location = st_buffer(p2, .01), warn = FALSE))
 })
 
 

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -16,7 +16,8 @@ test_that("NLDI messageing NULL", {
     distance_km = 2
   ))
 
-  expect_true(nrow(xx) == 1)
+  expect_true(class(xx) == "list")
+  expect_true(nrow(xx[[1]]) == 1)
 })
 
 
@@ -39,29 +40,29 @@ test_that("NLDI starting sources...", {
   skip_on_cran()
 
   # LINESTRING GEOMETERY
-  expect_equal(sum(names(findNLDI(comid = 101)) %in%
+  expect_equal(sum(names(findNLDI(comid = 101)$origin) %in%
     c("sourceName", "identifier", "comid", "geometry")), 4)
   # POINT GEOMETERY
-  expect_true(all(names(findNLDI(nwis = "11120000")) %in%
+  expect_true(all(names(findNLDI(nwis = "11120000")$origin) %in%
     c(
       "sourceName", "identifier", "comid",
       "name", "reachcode", "measure",
       "X", "Y", "geometry"
     )))
   # COMID
-  expect_equal(findNLDI(comid = 101)$sourceName, "NHDPlus comid")
+  expect_equal(findNLDI(comid = 101)$origin$sourceName, "NHDPlus comid")
   # NWIS
-  expect_equal(findNLDI(nwis = "11120000")$sourceName, "NWIS Surface Water Sites")
+  expect_equal(findNLDI(nwis = "11120000")$origin$sourceName, "NWIS Surface Water Sites")
   # WQP
-  expect_equal(findNLDI(wqp = "USGS-04024315")$sourceName, "Water Quality Portal")
+  expect_equal(findNLDI(wqp = "USGS-04024315")$origin$sourceName, "Water Quality Portal")
   # LOCATION
-  expect_equal(findNLDI(location = c(-115, 40))$sourceName, "NHDPlus comid")
+  expect_equal(findNLDI(location = c(-115, 40))$origin$sourceName, "NHDPlus comid")
   # ERROR: LOCATION COORDINATES FLIPPED
   expect_error(findNLDI(location = c(40, -115)))
   # GENERAL START: STABLE
-  expect_equal(findNLDI(origin = list("comid" = 101))$sourceName, "NHDPlus comid")
+  expect_equal(findNLDI(origin = list("comid" = 101))$origin$sourceName, "NHDPlus comid")
   # GENERAL START: NON-STABLE
-  expect_equal(findNLDI(origin = list("wade" = "NMwr_S148023"))$sourceName, "Water Data Exchange 2.0 Sites")
+  expect_equal(findNLDI(origin = list("wade" = "NMwr_S148023"))$origin$sourceName, "Water Data Exchange 2.0 Sites")
   # ERROR: TWO STARTS
   expect_error(findNLDI(nwis = 1000, comid = 101))
   # NON EXISTING SITE
@@ -72,11 +73,11 @@ test_that("NLDI navigation sources...", {
   skip_on_cran()
 
   # UPPER TRIBUTARY
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "UT")), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "UT")$UT_flowlines), 2)
   # UPPER MAIN
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "UM")), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "UM")$UM_flowlines), 2)
   # DOWNSTREAM MAIN
-  expect_equal(length(findNLDI(nwis = "11120000", nav = "DM")), 2)
+  expect_equal(length(findNLDI(nwis = "11120000", nav = "DM")$DM_flowlines), 2)
   # MULTI-REQUEST
   expect_equal(length(findNLDI(nwis = "11120000", nav = c("UT", "UM"))), 3)
   # ERRORS: Bad NAV REQUEST
@@ -137,4 +138,27 @@ test_that("sf points", {
   p2 <- st_sfc(st_point(c(-119.8458, 34.4146)), crs = 4326)
   expect_equal(findNLDI(location = p2), findNLDI(location = sf::st_as_sf(p2)))
   expect_error(findNLDI(location = st_buffer(p2, .01)))
+})
+
+
+test_that("warn_flag", {
+  
+  expect_warning(
+    findNLDI(wqp = "TCEQMAIN-10016",
+             nav = "UM",
+             find = "nwissite",
+             distance_km = 2,
+             no_sf = TRUE,
+             warn = FALSE),
+    regexp = NA
+  )
+
+  expect_warning(
+  findNLDI(wqp = "TCEQMAIN-10016",
+           nav = "UM",
+           find = "nwissite",
+           distance_km = 2,
+           no_sf = TRUE,
+           warn = TRUE)
+  )
 })


### PR DESCRIPTION
All with respect to USGS-R/dataRetrieval #623:

Hi @ldecicco-USGS!

This PR does four things:

1. Ensures that all returned objects are a list structure (even when a single element exists)
2. Fixes a bug where a space was added to the URL constructor for distance arguments
3. Adds a warn flag to `get_nldi` and `findNLDI` to optionally suppress warning messages
4. Updates all tests


All tests pass locally and documentation has been updated!

Let me know if anything else is needed,

Mike