### PR TITLE
Update dependency requirement: `curl` >=7.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Copyright: This software is in the public domain because it contains materials
 Depends:
     R (>= 4.1.0)
 Imports:
-    curl (>= 6.0.0),
+    curl (>= 7.0.0),
     lubridate (>= 1.5.0),
     stats,
     utils,


### PR DESCRIPTION
Fixes #827. This very small PR modifies the version requirement of the dependency `curl` in the `DESCRIPTION` file.