### PR TITLE
Commas

### DIFF
--- a/R/construct_api_requests.R
+++ b/R/construct_api_requests.R
@@ -51,6 +51,11 @@ construct_api_requests <- function(service,
   comma_params <- c("monitoring_location_id", "parameter_code", 
                     "statistic_id", "time_series_id")
   
+  if(service %in% c("monitoring-locations", "parameter-codes", 
+                    "time-series-metadata")){
+    comma_params <- c(comma_params, "id")
+  }
+  
   full_list <- list(...)
   
   if(all(is.na(full_list)) & all(is.na(bbox))){

--- a/R/construct_api_requests.R
+++ b/R/construct_api_requests.R
@@ -45,7 +45,11 @@ construct_api_requests <- function(service,
   
   POST <- FALSE
   
-  single_params <- c("datetime", "last_modified", "begin", "end", "time", "limit")
+  single_params <- c("datetime", "last_modified", 
+                     "begin", "end", "time", "limit",
+                     "begin_utc", "end_utc")
+  comma_params <- c("monitoring_location_id", "parameter_code", 
+                    "statistic_id", "time_series_id")
   
   full_list <- list(...)
   
@@ -54,12 +58,12 @@ construct_api_requests <- function(service,
   }
   
   # GET list refers to arguments that will go in the URL no matter what (not POST)
-  get_list <- full_list[names(full_list) %in% single_params]
+  get_list <- full_list[names(full_list) %in% c(single_params, comma_params)]
 
   get_list[["skipGeometry"]] <- skipGeometry
   
   #POST list are the arguments that need to be in the POST body
-  post_list <- full_list[!names(full_list) %in% single_params]
+  post_list <- full_list[!names(full_list) %in% c(single_params, comma_params)]
   
   post_params <- explode_post(post_list)
   
@@ -69,7 +73,7 @@ construct_api_requests <- function(service,
   
   get_list <- get_list[!is.na(get_list)]
   
-  time_periods <- c("last_modified", "datetime", "time", "begin", "end")
+  time_periods <- c("last_modified", "datetime", "time", "begin", "end", "begin_utc", "end_utc")
   if(any(time_periods %in% names(get_list))){
 
     for(i in time_periods[time_periods %in% names(get_list)]){
@@ -85,7 +89,7 @@ construct_api_requests <- function(service,
   format_type <- ifelse(isTRUE(no_paging), "csv", "json")
   
   baseURL <- setup_api(service, format = format_type)
-  baseURL <- explode_query(baseURL, POST = FALSE, get_list)
+  baseURL <- explode_query(baseURL, POST = FALSE, get_list, multi = "comma")
   
   if(all(!is.na(bbox))){
     baseURL <- httr2::req_url_query(baseURL,
@@ -111,7 +115,7 @@ construct_api_requests <- function(service,
                                     .multi = "comma")    
   }
   
-  if(POST){  
+  if(POST){
     baseURL <- baseURL |>
       httr2::req_headers(`Content-Type` = "application/query-cql-json") 
     
@@ -126,7 +130,7 @@ construct_api_requests <- function(service,
     baseURL <- httr2::req_body_raw(baseURL, x) 
     
   } else {
-    baseURL <- explode_query(baseURL, POST = FALSE, full_list)
+    baseURL <- explode_query(baseURL, POST = FALSE, full_list, multi = "comma")
   }
   
   return(baseURL)

--- a/R/construct_api_requests.R
+++ b/R/construct_api_requests.R
@@ -49,7 +49,9 @@ construct_api_requests <- function(service,
                      "begin", "end", "time", "limit",
                      "begin_utc", "end_utc")
   comma_params <- c("monitoring_location_id", "parameter_code", 
-                    "statistic_id", "time_series_id")
+                    "statistic_id", "time_series_id",
+                    "computation_period_identifier",
+                    "computation_identifier")
   
   if(service %in% c("monitoring-locations", #"parameter-codes", 
                     "time-series-metadata")){

--- a/R/get_ogc_data.R
+++ b/R/get_ogc_data.R
@@ -25,12 +25,7 @@ get_ogc_data <- function(args,
   
   req <- do.call(construct_api_requests, args)
 
-  if("no_paging" %in% names(args)){
-    no_paging <- args[["no_paging"]]
-    args[["no_paging"]] <- NULL    
-  } else {
-    no_paging <- FALSE
-  }
+  no_paging <- grepl("f=csv", req$url)
   
   message("Requesting:\n", req$url)
   
@@ -68,7 +63,7 @@ get_ogc_data <- function(args,
   
   attr(return_list, "request") <- req
   attr(return_list, "queryTime") <- Sys.time()
-  return_list
+  return(return_list)
 }
 
 order_results <- function(df){

--- a/R/read_waterdata_continuous.R
+++ b/R/read_waterdata_continuous.R
@@ -27,9 +27,6 @@
 #' @param time_series_id `r get_params("continuous")$time_series_id`
 #' Multiple time_series_ids can be requested as a character vector.
 #' @param qualifier `r get_params("continuous")$qualifier`
-#' @param statistic_id `r get_params("continuous")$statistic_id`. Note that 
-#' for continuous data, the statistic_id is almost universally 00011. 
-#' Requesting anything else will most-likely cause a timeout. 
 #' @param properties A vector of requested columns to be returned from the query.
 #' Available options are: 
 #' `r dataRetrieval:::get_properties_for_docs("continuous", "continuous_id")`.
@@ -76,7 +73,6 @@ read_waterdata_continuous <- function(monitoring_location_id = NA_character_,
                                       approval_status = NA_character_,
                                       unit_of_measure = NA_character_,
                                       qualifier = NA_character_,
-                                      statistic_id = NA_character_,
                                       value = NA,
                                       last_modified = NA_character_,
                                       time = NA_character_,
@@ -90,10 +86,6 @@ read_waterdata_continuous <- function(monitoring_location_id = NA_character_,
   args <- mget(names(formals()))
   args[["skipGeometry"]] <- TRUE
 
-  if(!is.na(statistic_id) & !all(statistic_id == "00011")){
-    warning("With few if any exceptions, statistic_id is always 00011 for continuous data, and requesting other statistic ids will likely return no data.")
-  }
-  
   return_list <- get_ogc_data(args,
                               output_id, 
                               service)

--- a/R/read_waterdata_continuous.R
+++ b/R/read_waterdata_continuous.R
@@ -8,11 +8,13 @@
 #' for new direct download functions that are expected to be available sometime
 #' in 2026.
 #' 
-#' Geometry output is not supported in the continuous data API
+#' Geometry output is not supported in the continuous data API endpoint.
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("continuous")$monitoring_location_id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param parameter_code `r get_params("continuous")$parameter_code`
+#' Multiple parameter_codes can be requested as a character vector.
 #' @param time `r get_params("continuous")$time`. 
 #' You can also use a vector of length 2: the first value being the starting date,
 #' the second value being the ending date. NA's within the vector indicate a
@@ -23,6 +25,7 @@
 #' @param approval_status `r get_params("continuous")$approval_status`
 #' @param last_modified `r get_params("continuous")$last_modified`
 #' @param time_series_id `r get_params("continuous")$time_series_id`
+#' Multiple time_series_ids can be requested as a character vector.
 #' @param qualifier `r get_params("continuous")$qualifier`
 #' @param statistic_id `r get_params("continuous")$statistic_id`. Note that 
 #' for continuous data, the statistic_id is almost universally 00011. 

--- a/R/read_waterdata_daily.R
+++ b/R/read_waterdata_daily.R
@@ -4,8 +4,11 @@
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("daily")$monitoring_location_id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param parameter_code `r get_params("daily")$parameter_code`
+#' Multiple parameter_codes can be requested as a character vector.
 #' @param statistic_id `r get_params("daily")$statistic_id`
+#' Multiple statistic_ids can be requested as a character vector.
 #' @param time `r get_params("daily")$time`
 #' You can also use a vector of length 2: the first value being the starting date,
 #' the second value being the ending date. NA's within the vector indicate a
@@ -16,6 +19,7 @@
 #' @param approval_status `r get_params("daily")$approval_status`
 #' @param last_modified `r get_params("daily")$last_modified`
 #' @param time_series_id `r get_params("daily")$time_series_id`
+#' Multiple time_series_ids can be requested as a character vector.
 #' @param qualifier `r get_params("daily")$qualifier`
 #' @param properties A vector of requested columns to be returned from the query.
 #' Available options are: 

--- a/R/read_waterdata_daily.R
+++ b/R/read_waterdata_daily.R
@@ -79,6 +79,9 @@
 #' dv_data_quick <- read_waterdata_daily(monitoring_location_id = site,
 #'                                    parameter_code = "00060",
 #'                                    no_paging = TRUE)
+#'                                    
+#' dv_post <- read_waterdata_daily(monitoring_location_id = site,
+#'                                 approval_status = c("Approved", "Provisional"))
 #' 
 #' }
 read_waterdata_daily <- function(monitoring_location_id = NA_character_,

--- a/R/read_waterdata_field_measurements.R
+++ b/R/read_waterdata_field_measurements.R
@@ -4,7 +4,9 @@
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("field-measurements")$monitoring_location_id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param parameter_code `r get_params("field-measurements")$parameter_code`
+#' Multiple parameter_codes can be requested as a character vector.
 #' @param observing_procedure_code `r get_params("field-measurements")$observing_procedure_code`
 #' @param time `r get_params("field-measurements")$time`
 #' You can also use a vector of length 2: the first value being the starting date,

--- a/R/read_waterdata_latest_continuous.R
+++ b/R/read_waterdata_latest_continuous.R
@@ -4,7 +4,9 @@
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("latest-continuous")$monitoring_location_id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param parameter_code `r get_params("latest-continuous")$parameter_code`
+#' Multiple parameter_codes can be requested as a character vector.
 #' @param time `r get_params("latest-continuous")$time`
 #' You can also use a vector of length 2: the first value being the starting date,
 #' the second value being the ending date. NA's within the vector indicate a
@@ -15,6 +17,7 @@
 #' @param approval_status `r get_params("latest-continuous")$approval_status`
 #' @param last_modified `r get_params("latest-continuous")$last_modified`
 #' @param time_series_id `r get_params("latest-continuous")$time_series_id`
+#' Multiple time_series_ids can be requested as a character vector.
 #' @param qualifier `r get_params("latest-continuous")$qualifier`
 #' @param statistic_id `r get_params("latest-continuous")$statistic_id`. Note that 
 #' for continuous data, the statistic_id is almost universally 00011. 

--- a/R/read_waterdata_latest_continuous.R
+++ b/R/read_waterdata_latest_continuous.R
@@ -19,9 +19,6 @@
 #' @param time_series_id `r get_params("latest-continuous")$time_series_id`
 #' Multiple time_series_ids can be requested as a character vector.
 #' @param qualifier `r get_params("latest-continuous")$qualifier`
-#' @param statistic_id `r get_params("latest-continuous")$statistic_id`. Note that 
-#' for continuous data, the statistic_id is almost universally 00011. 
-#' Requesting anything else will most-likely cause a timeout. 
 #' @param properties A vector of requested columns to be returned from the query.
 #' Available options are: 
 #' `r dataRetrieval:::get_properties_for_docs("latest-continuous", "latest_continuous_id")`.
@@ -82,7 +79,6 @@
 #' }
 read_waterdata_latest_continuous <- function(monitoring_location_id = NA_character_,
                             parameter_code = NA_character_,
-                            statistic_id = NA_character_,
                             properties = NA_character_,
                             time_series_id = NA_character_,
                             approval_status = NA_character_,

--- a/R/read_waterdata_latest_daily.R
+++ b/R/read_waterdata_latest_daily.R
@@ -4,8 +4,11 @@
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("latest-daily")$monitoring_location_id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param parameter_code `r get_params("latest-daily")$parameter_code`
+#' Multiple parameter_codes can be requested as a character vector.
 #' @param statistic_id `r get_params("latest-daily")$statistic_id`
+#' Multiple statistic_ids can be requested as a character vector.
 #' @param time `r get_params("latest-daily")$time`
 #' You can also use a vector of length 2: the first value being the starting date,
 #' the second value being the ending date. NA's within the vector indicate a
@@ -16,6 +19,7 @@
 #' @param approval_status `r get_params("latest-daily")$approval_status`
 #' @param last_modified `r get_params("latest-daily")$last_modified`
 #' @param time_series_id `r get_params("latest-daily")$time_series_id`
+#' Multiple time_series_ids can be requested as a character vector.
 #' @param qualifier `r get_params("latest-daily")$qualifier`
 #' @param properties A vector of requested columns to be returned from the query.
 #' Available options are: 

--- a/R/read_waterdata_monitoring_location.R
+++ b/R/read_waterdata_monitoring_location.R
@@ -4,6 +4,7 @@
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("monitoring-locations")$id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param agency_code `r get_params("monitoring-locations")$agency_code`
 #' @param agency_name `r get_params("monitoring-locations")$agency_name`
 #' @param monitoring_location_number `r get_params("monitoring-locations")$monitoring_location_number`

--- a/R/read_waterdata_parameter_codes.R
+++ b/R/read_waterdata_parameter_codes.R
@@ -65,26 +65,10 @@ read_waterdata_parameter_codes <- function(parameter_code = NA_character_,
   args[["skipGeometry"]] <- TRUE
   args[["bbox"]] <- NA
   args[["no_paging"]] <- FALSE # drops id if TRUE
-  
-  if(all(lengths(args) == 1)){
-    return_list <- suppressWarnings(get_ogc_data(args = args,
-                                                 output_id = output_id,
-                                                 service =  service))
-  } else {
-    
-    message("Current API functionality requires pulling the full parameter-codes list.
-It is expected that updates to the API will eliminate this need.")
-    
-    return_list <- read_waterdata_metadata(collection = service, 
-                                           limit = limit)
-    args[["convertType"]] <- NULL
-    args[["skipGeometry"]] <- NULL
-    args[["no_paging"]] <- NULL
-    args_to_filter <- args[!is.na(args)]
-    for(param in names(args_to_filter)){
-      return_list <- return_list[return_list[[param]] %in% args_to_filter[[param]],]
-    }
-  }
+
+  return_list <- get_ogc_data(args = args,
+                              output_id = output_id,
+                              service =  service)
 
   return(return_list)
 }

--- a/R/read_waterdata_samples.R
+++ b/R/read_waterdata_samples.R
@@ -293,7 +293,7 @@ check_profile <- function(dataProfile, profile_convert){
   return(dataProfile)
 }
 
-explode_query <- function(baseURL, POST = FALSE, x){
+explode_query <- function(baseURL, POST = FALSE, x, multi = "explode"){
   
   if(!is.list(x)){
     return(baseURL)
@@ -307,7 +307,7 @@ explode_query <- function(baseURL, POST = FALSE, x){
     } else {
       baseURL <- httr2::req_url_query(baseURL,
                                       !!!x,
-                                      .multi = "explode")   
+                                      .multi = multi)   
     }
     
   }

--- a/R/read_waterdata_ts_meta.R
+++ b/R/read_waterdata_ts_meta.R
@@ -11,7 +11,9 @@
 #' @param statistic_id `r get_params("time-series-metadata")$statistic_id`
 #' Multiple statistic_ids can be requested as a character vector.
 #' @param computation_identifier `r get_params("time-series-metadata")$computation_identifier`
+#' Multiple computation_identifiers can be requested as a character vector.
 #' @param computation_period_identifier `r get_params("time-series-metadata")$computation_period_identifier`
+#' Multiple computation_period_identifiers can be requested as a character vector.
 #' @param sublocation_identifier `r get_params("time-series-metadata")$sublocation_identifier`
 #' @param last_modified `r get_params("time-series-metadata")$last_modified`
 #' @param begin_utc `r get_params("time-series-metadata")$begin_utc`

--- a/R/read_waterdata_ts_meta.R
+++ b/R/read_waterdata_ts_meta.R
@@ -4,9 +4,12 @@
 #' 
 #' @export
 #' @param monitoring_location_id `r get_params("time-series-metadata")$monitoring_location_id`
+#' Multiple monitoring_location_ids can be requested as a character vector.
 #' @param parameter_code `r get_params("time-series-metadata")$parameter_code`
+#' Multiple parameter_codes can be requested as a character vector.
 #' @param parameter_name `r get_params("time-series-metadata")$parameter_name`
 #' @param statistic_id `r get_params("time-series-metadata")$statistic_id`
+#' Multiple statistic_ids can be requested as a character vector.
 #' @param computation_identifier `r get_params("time-series-metadata")$computation_identifier`
 #' @param computation_period_identifier `r get_params("time-series-metadata")$computation_period_identifier`
 #' @param sublocation_identifier `r get_params("time-series-metadata")$sublocation_identifier`

--- a/man/read_waterdata_continuous.Rd
+++ b/man/read_waterdata_continuous.Rd
@@ -22,16 +22,22 @@ read_waterdata_continuous(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
 
-\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.}
+Multiple monitoring_location_ids can be requested as a character vector.}
+
+\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
+
+Multiple parameter_codes can be requested as a character vector.}
 
 \item{properties}{A vector of requested columns to be returned from the query.
 Available options are:
 geometry, continuous_id, internal_id, time_series_id, monitoring_location_id, parameter_code, statistic_id, time, value, unit_of_measure, approval_status, qualifier, last_modified.
 The default (\code{NA}) will return all columns of the data.}
 
-\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.}
+\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.
+
+Multiple time_series_ids can be requested as a character vector.}
 
 \item{approval_status}{Some of the data that you have obtained from this U.S. Geological Survey database may not have received Director's approval.  Any such data values are qualified as provisional and are subject to revision.  Provisional data are released on the condition that neither the USGS nor the United States Government may be held liable for any damages resulting from its use. This field reflects the approval status of each record, and is either "Approved", meaining processing review has been completed and the data is approved for publication, or "Provisional" and subject to revision. For more information about provisional data, go to \url{https://waterdata.usgs.gov/provisional-data-statement/}.}
 
@@ -99,7 +105,7 @@ last single year of data. If this is a bottleneck, please check back
 for new direct download functions that are expected to be available sometime
 in 2026.
 
-Geometry output is not supported in the continuous data API
+Geometry output is not supported in the continuous data API endpoint.
 }
 \examples{
 \dontshow{if (is_dataRetrieval_user()) withAutoprint(\{ # examplesIf}

--- a/man/read_waterdata_continuous.Rd
+++ b/man/read_waterdata_continuous.Rd
@@ -12,7 +12,6 @@ read_waterdata_continuous(
   approval_status = NA_character_,
   unit_of_measure = NA_character_,
   qualifier = NA_character_,
-  statistic_id = NA_character_,
   value = NA,
   last_modified = NA_character_,
   time = NA_character_,
@@ -44,11 +43,6 @@ Multiple time_series_ids can be requested as a character vector.}
 \item{unit_of_measure}{A human-readable description of the units of measurement associated with an observation.}
 
 \item{qualifier}{This field indicates any qualifiers associated with an observation, for instance if a sensor may have been impacted by ice or if values were estimated.}
-
-\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.
-. Note that
-for continuous data, the statistic_id is almost universally 00011.
-Requesting anything else will most-likely cause a timeout.}
 
 \item{value}{The value of the observation. Values are transmitted as strings in the JSON response format in order to preserve precision.}
 

--- a/man/read_waterdata_daily.Rd
+++ b/man/read_waterdata_daily.Rd
@@ -24,18 +24,26 @@ read_waterdata_daily(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
 
-\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.}
+Multiple monitoring_location_ids can be requested as a character vector.}
 
-\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.}
+\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
+
+Multiple parameter_codes can be requested as a character vector.}
+
+\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.
+
+Multiple statistic_ids can be requested as a character vector.}
 
 \item{properties}{A vector of requested columns to be returned from the query.
 Available options are:
 geometry, daily_id, time_series_id, monitoring_location_id, parameter_code, statistic_id, time, value, unit_of_measure, approval_status, qualifier, last_modified.
 The default (\code{NA}) will return all columns of the data.}
 
-\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.}
+\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.
+
+Multiple time_series_ids can be requested as a character vector.}
 
 \item{approval_status}{Some of the data that you have obtained from this U.S. Geological Survey database may not have received Director's approval.  Any such data values are qualified as provisional and are subject to revision.  Provisional data are released on the condition that neither the USGS nor the United States Government may be held liable for any damages resulting from its use. This field reflects the approval status of each record, and is either "Approved", meaining processing review has been completed and the data is approved for publication, or "Provisional" and subject to revision. For more information about provisional data, go to \url{https://waterdata.usgs.gov/provisional-data-statement/}.}
 

--- a/man/read_waterdata_daily.Rd
+++ b/man/read_waterdata_daily.Rd
@@ -144,6 +144,9 @@ multi_site <- read_waterdata_daily(monitoring_location_id =  c("USGS-01491000",
 dv_data_quick <- read_waterdata_daily(monitoring_location_id = site,
                                    parameter_code = "00060",
                                    no_paging = TRUE)
+                                   
+dv_post <- read_waterdata_daily(monitoring_location_id = site,
+                                approval_status = c("Approved", "Provisional"))
 
 }
 \dontshow{\}) # examplesIf}

--- a/man/read_waterdata_field_measurements.Rd
+++ b/man/read_waterdata_field_measurements.Rd
@@ -27,9 +27,13 @@ read_waterdata_field_measurements(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
 
-\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.}
+Multiple monitoring_location_ids can be requested as a character vector.}
+
+\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
+
+Multiple parameter_codes can be requested as a character vector.}
 
 \item{observing_procedure_code}{A short code corresponding to the observing procedure for the field measurement.}
 

--- a/man/read_waterdata_latest_continuous.Rd
+++ b/man/read_waterdata_latest_continuous.Rd
@@ -24,9 +24,13 @@ read_waterdata_latest_continuous(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
 
-\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.}
+Multiple monitoring_location_ids can be requested as a character vector.}
+
+\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
+
+Multiple parameter_codes can be requested as a character vector.}
 
 \item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.
 . Note that
@@ -38,7 +42,9 @@ Available options are:
 geometry, latest_continuous_id, time_series_id, monitoring_location_id, parameter_code, statistic_id, time, value, unit_of_measure, approval_status, qualifier, last_modified.
 The default (\code{NA}) will return all columns of the data.}
 
-\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.}
+\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.
+
+Multiple time_series_ids can be requested as a character vector.}
 
 \item{approval_status}{Some of the data that you have obtained from this U.S. Geological Survey database may not have received Director's approval.  Any such data values are qualified as provisional and are subject to revision.  Provisional data are released on the condition that neither the USGS nor the United States Government may be held liable for any damages resulting from its use. This field reflects the approval status of each record, and is either "Approved", meaining processing review has been completed and the data is approved for publication, or "Provisional" and subject to revision. For more information about provisional data, go to \url{https://waterdata.usgs.gov/provisional-data-statement/}.}
 

--- a/man/read_waterdata_latest_continuous.Rd
+++ b/man/read_waterdata_latest_continuous.Rd
@@ -7,7 +7,6 @@
 read_waterdata_latest_continuous(
   monitoring_location_id = NA_character_,
   parameter_code = NA_character_,
-  statistic_id = NA_character_,
   properties = NA_character_,
   time_series_id = NA_character_,
   approval_status = NA_character_,
@@ -31,11 +30,6 @@ Multiple monitoring_location_ids can be requested as a character vector.}
 \item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
 
 Multiple parameter_codes can be requested as a character vector.}
-
-\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.
-. Note that
-for continuous data, the statistic_id is almost universally 00011.
-Requesting anything else will most-likely cause a timeout.}
 
 \item{properties}{A vector of requested columns to be returned from the query.
 Available options are:

--- a/man/read_waterdata_latest_daily.Rd
+++ b/man/read_waterdata_latest_daily.Rd
@@ -24,18 +24,26 @@ read_waterdata_latest_daily(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
 
-\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.}
+Multiple monitoring_location_ids can be requested as a character vector.}
 
-\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.}
+\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
+
+Multiple parameter_codes can be requested as a character vector.}
+
+\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.
+
+Multiple statistic_ids can be requested as a character vector.}
 
 \item{properties}{A vector of requested columns to be returned from the query.
 Available options are:
 geometry, latest_daily_id, time_series_id, monitoring_location_id, parameter_code, statistic_id, time, value, unit_of_measure, approval_status, qualifier, last_modified.
 The default (\code{NA}) will return all columns of the data.}
 
-\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.}
+\item{time_series_id}{A unique identifier representing a single time series. This corresponds to the \code{id} field in the \code{time-series-metadata} endpoint.
+
+Multiple time_series_ids can be requested as a character vector.}
 
 \item{approval_status}{Some of the data that you have obtained from this U.S. Geological Survey database may not have received Director's approval.  Any such data values are qualified as provisional and are subject to revision.  Provisional data are released on the condition that neither the USGS nor the United States Government may be held liable for any damages resulting from its use. This field reflects the approval status of each record, and is either "Approved", meaining processing review has been completed and the data is approved for publication, or "Provisional" and subject to revision. For more information about provisional data, go to \url{https://waterdata.usgs.gov/provisional-data-statement/}.}
 

--- a/man/read_waterdata_monitoring_location.Rd
+++ b/man/read_waterdata_monitoring_location.Rd
@@ -52,7 +52,9 @@ read_waterdata_monitoring_location(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
+
+Multiple monitoring_location_ids can be requested as a character vector.}
 
 \item{agency_code}{The agency that is reporting the data. Agency codes are fixed values assigned by the National Water Information System (NWIS). A list of agency codes is available \href{https://help.waterdata.usgs.gov/code/agency_cd_query?fmt=html}{at this link}.}
 

--- a/man/read_waterdata_ts_meta.Rd
+++ b/man/read_waterdata_ts_meta.Rd
@@ -35,9 +35,13 @@ read_waterdata_ts_meta(
 )
 }
 \arguments{
-\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).}
+\item{monitoring_location_id}{A unique identifier representing a single monitoring location. This corresponds to the \code{id} field in the \code{monitoring-locations} endpoint. Monitoring location IDs are created by combining the agency code of the agency responsible for the monitoring location (e.g. USGS) with the ID number of the monitoring location (e.g. 02238500), separated by a hyphen (e.g. USGS-02238500).
 
-\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.}
+Multiple monitoring_location_ids can be requested as a character vector.}
+
+\item{parameter_code}{Parameter codes are 5-digit codes used to identify the constituent measured and the units of measure. A complete list of parameter codes and associated groupings can be found at \url{https://help.waterdata.usgs.gov/codes-and-parameters/parameters}.
+
+Multiple parameter_codes can be requested as a character vector.}
 
 \item{parameter_name}{A human-understandable name corresponding to \code{parameter_code}.}
 
@@ -46,7 +50,9 @@ Available options are:
 geometry, time_series_id, unit_of_measure, parameter_name, parameter_code, statistic_id, hydrologic_unit_code, state_name, last_modified, begin, end, begin_utc, end_utc, computation_period_identifier, computation_identifier, thresholds, sublocation_identifier, primary, monitoring_location_id, web_description, parameter_description, parent_time_series_id.
 The default (\code{NA}) will return all columns of the data.}
 
-\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.}
+\item{statistic_id}{A code corresponding to the statistic an observation represents. Example codes include 00001 (max), 00002 (min), and 00003 (mean). A complete list of codes and their descriptions can be found at \url{https://help.waterdata.usgs.gov/code/stat_cd_nm_query?stat_nm_cd=\%25&fmt=html}.
+
+Multiple statistic_ids can be requested as a character vector.}
 
 \item{last_modified}{The last time a record was refreshed in our database. This may happen due to regular operational processes and does not necessarily indicate anything about the measurement has changed.
 You can query this field using date-times or intervals, adhering to RFC 3339, or using ISO 8601 duration objects. Intervals may be bounded or half-bounded (double-dots at start or end).

--- a/man/read_waterdata_ts_meta.Rd
+++ b/man/read_waterdata_ts_meta.Rd
@@ -96,9 +96,11 @@ Only features that have a \code{end} that intersects the value of datetime are s
 
 \item{unit_of_measure}{A human-readable description of the units of measurement associated with an observation.}
 
-\item{computation_period_identifier}{Indicates the period of data used for any statistical computations.}
+\item{computation_period_identifier}{Indicates the period of data used for any statistical computations.
+Multiple computation_period_identifiers can be requested as a character vector.}
 
-\item{computation_identifier}{Indicates whether the data from this time series represent a specific statistical computation.}
+\item{computation_identifier}{Indicates whether the data from this time series represent a specific statistical computation.
+Multiple computation_identifiers can be requested as a character vector.}
 
 \item{thresholds}{Thresholds represent known numeric limits for a time series, for example the historic maximum value for a parameter or a level below which a sensor is non-operative. These thresholds are sometimes used to automatically determine if an observation is erroneous due to sensor error, and therefore shouldn't be included in the time series.}
 

--- a/tests/testthat/tests_userFriendly_fxns.R
+++ b/tests/testthat/tests_userFriendly_fxns.R
@@ -491,7 +491,7 @@ context("pCode Stuff")
 test_that("pCode Stuff", {
   testthat::skip_on_cran()
 
-  paramINFO <- read_waterdata_parameter_codes(parameter_code = c("00060", "01075", "00931", NA))
+  paramINFO <- read_waterdata_parameter_codes(parameter_code = c("00060", "01075", "00931"))
   expect_equal(nrow(paramINFO), 3)
   expect_true(all(paramINFO$parameter_code %in% c("00060", "01075", "00931")))
   

--- a/tests/testthat/tests_userFriendly_fxns.R
+++ b/tests/testthat/tests_userFriendly_fxns.R
@@ -391,7 +391,7 @@ test_that("Construct USGS urls", {
   
   # nolint start: line_length_linter
   expect_equal(url_daily$url,
-               "https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily/items?f=json&lang=en-US&time=2024-01-01%2F..&limit=10000&skipGeometry=FALSE")
+               "https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily/items?f=json&lang=en-US&skipGeometry=FALSE&monitoring_location_id=USGS-01594440&parameter_code=00060,00010&time=2024-01-01%2F..&statistic_id=00003,00001&limit=10000")
 
   url_works <- dataRetrieval:::walk_pages(url_daily)
   expect_true(nrow(url_works) > 0)
@@ -403,7 +403,7 @@ test_that("Construct USGS urls", {
   
   expect_equal(
     url_ts_meta$url,
-    "https://api.waterdata.usgs.gov/ogcapi/v0/collections/time-series-metadata/items?f=json&lang=en-US&limit=10000&skipGeometry=FALSE"
+    "https://api.waterdata.usgs.gov/ogcapi/v0/collections/time-series-metadata/items?f=json&lang=en-US&skipGeometry=FALSE&monitoring_location_id=USGS-01594440&parameter_code=00060,00010&limit=10000"
   )
   
   url_works_ts <- dataRetrieval:::walk_pages(url_ts_meta)


### PR DESCRIPTION
Take advantage of monitoring locations, parameter codes, statistic ids, and time series ids now can have commas in the GET rather than doing a POST with CQL