### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 version](http://www.r-pkg.org/badges/version/dataRetrieval)](https://cran.r-project.org/package=dataRetrieval)
 [![](http://cranlogs.r-pkg.org/badges/dataRetrieval)](https://cran.r-project.org/package=dataRetrieval)
 [![](http://cranlogs.r-pkg.org/badges/grand-total/dataRetrieval)](https://cran.r-project.org/package=dataRetrieval)
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/DOI-USGS/dataRetrieval)
 
 The `dataRetrieval` package was created to simplify the process of
 loading hydrologic data into the R environment. It is designed to


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/DOI-USGS/dataRetrieval) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.