### PR TITLE
nldi client tweaks

### DIFF
--- a/R/AAA.R
+++ b/R/AAA.R
@@ -2,8 +2,8 @@ pkg.env <- new.env()
 
 .onLoad <- function(libname, pkgname) {
   suppressMessages(setAccess("public"))
-  pkg.env$nldi_base <- "https://api.water.usgs.gov/nldi/linked-data/"
   pkg.env$local_sf <- requireNamespace("sf", quietly = TRUE)
+  options("dataRetrieval.nldi_base" = "https://api.water.usgs.gov/nldi/linked-data/")
   options("dataRetrieval.api_version" = "v0")
   options("dataRetrieval.api_version_stat" = "v0")
   options("dataRetrieval.attach_request" = TRUE)

--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -27,7 +27,9 @@ find_good_names <- function(input, type) {
       "sourceName",
       "identifier",
       "comid",
-      names(input)[names(input) %in% c("name", "reachcode", "measure")]
+      names(input)[
+        names(input) %in% c("name", "reachcode", "measure", "mainstem")
+      ]
     )
   } else {
     NULL
@@ -44,7 +46,7 @@ find_good_names <- function(input, type) {
 #' \donttest{
 #' get_nldi_sources()
 #' }
-get_nldi_sources <- function(url = pkg.env$nldi_base) {
+get_nldi_sources <- function(url = getOption("dataRetrieval.nldi_base")) {
   res <- httr2::request(url)
   res <- httr2::req_user_agent(res, default_ua())
   res <- httr2::req_error(res, is_error = \(x) FALSE)
@@ -357,7 +359,7 @@ findNLDI <- function(
 
     # Must convert location to COMID for tracing and discovery ...
     tmp_url <- paste0(
-      pkg.env$nldi_base,
+      getOption("dataRetrieval.nldi_base"),
       "comid/position?f=json&coords=POINT%28",
       location[1],
       "%20",
@@ -374,8 +376,15 @@ findNLDI <- function(
   # Reset (if needed)
   start_type <- names(starter)
 
-  if (is.null(pkg.env$current_nldi)) {
+  if (
+    is.null(pkg.env$current_nldi) ||
+      !identical(
+        pkg.env$current_nldi_base,
+        getOption("dataRetrieval.nldi_base")
+      )
+  ) {
     pkg.env$current_nldi <- get_nldi_sources()
+    pkg.env$current_nldi_base <- getOption("dataRetrieval.nldi_base")
   }
 
   # Defining the origin URL.

--- a/tests/testthat/tests_nldi.R
+++ b/tests/testthat/tests_nldi.R
@@ -51,6 +51,7 @@ test_that("NLDI starting sources...", {
         "identifier",
         "comid",
         "name",
+        "mainstem",
         "reachcode",
         "measure",
         "X",


### PR DESCRIPTION
The NLDI provides a mainstem ID that we need to add, and this also makes it so you can switch to a different endpoint with options -- I think I followed conventions from the rest of the package but am happy to switch things up if we need.