### PR TITLE
fix: don't request `id` as a property (omit it) for id/geometry-only OGC calls

### DIFF
--- a/R/get_ogc_data.R
+++ b/R/get_ogc_data.R
@@ -171,9 +171,14 @@ switch_properties_id <- function(properties, id) {
     }
 
     if (length(properties) == 0) {
-      # If a user requested only id and/or geometry, properties would now be empty
-      # geometry is taken care of with skipGeometry
-      properties <- "id"
+      # If a user requested only id and/or geometry, properties is now empty.
+      # The feature "id" always comes back (and geometry is handled by
+      # skipGeometry), so omit the properties filter entirely rather than
+      # requesting "id": several collections (e.g. daily, continuous) now
+      # reject "id" as a selectable property, and it also fails the
+      # available-properties check below. rejigger_cols() still subsets the
+      # result to the requested id column.
+      properties <- NA_character_
     }
   }
 

--- a/tests/testthat/tests_general.R
+++ b/tests/testthat/tests_general.R
@@ -648,3 +648,35 @@ test_that("format_dates", {
     "2025-10-01/2026-02-02"
   )
 })
+
+test_that("switch_properties_id drops id and geometry from the wire properties", {
+  # The feature "id" always comes back (renamed to the service id
+  # downstream) and several collections (e.g. daily, continuous) now reject
+  # "id" as a selectable property, so it must never be sent. A request for
+  # only id and/or geometry must omit the properties filter (NA), not fall
+  # back to "id".
+  expect_true(all(is.na(
+    dataRetrieval:::switch_properties_id("daily_id", id = "daily_id")
+  )))
+  expect_true(all(is.na(
+    dataRetrieval:::switch_properties_id("id", id = "daily_id")
+  )))
+  expect_true(all(is.na(
+    dataRetrieval:::switch_properties_id(c("daily_id", "geometry"), id = "daily_id")
+  )))
+
+  # Mixed requests: the id alias and geometry are dropped, real properties kept.
+  expect_equal(
+    dataRetrieval:::switch_properties_id(c("daily_id", "value"), id = "daily_id"),
+    "value"
+  )
+  expect_equal(
+    dataRetrieval:::switch_properties_id(c("id", "value", "geometry"), id = "daily_id"),
+    "value"
+  )
+
+  # No properties requested -> unchanged (NA passes through).
+  expect_true(all(is.na(
+    dataRetrieval:::switch_properties_id(NA, id = "daily_id")
+  )))
+})


### PR DESCRIPTION
## Problem

`read_waterdata_*(properties = "<id column>")` (or only id + geometry) errors:

```r
read_waterdata_daily(monitoring_location_id = "USGS-05427718",
                     parameter_code = "00060", time = "2025-01-01/..",
                     properties = "daily_id")
#> Error: Invalid properties: id
```

`switch_properties_id()` correctly strips the feature id and `geometry` from the wire `properties` (the feature `id` is always returned and renamed downstream; geometry is controlled by `skipGeometry`). But when the request was **only** the id and/or geometry, the list became empty and it fell back to `properties <- "id"`. That fallback no longer works: the USGS OGC API now rejects `id` as a selectable property on several collections (e.g. `daily`, `continuous`), and `id` also fails the available-properties check in `construct_api_requests()`.

This is the same upstream API change that affected the Python `dataretrieval` package; the R package's normal multi-property path already drops `id` correctly, so only the id/geometry-only fallback is affected.

## Fix

Fall back to `NA_character_` instead of `"id"`, which omits the `properties` filter entirely. The feature `id` still comes back regardless, and `rejigger_cols()` subsets the result to the requested column — so id/geometry-only requests now succeed on every collection.

Verified live:
- `daily` / `continuous` (reject `id`): previously errored, now return a valid result (the synthetic `daily_id`/`continuous_id` is dropped for these services by design, as before).
- `monitoring-locations` (accepts `id`, keeps the id column): returns the id column, unchanged from current behavior.

The only cost is that an id/geometry-only request now fetches all columns and subsets client-side (the API can no longer return just `id`); this is a rare request and avoids the error.

## Tests

Adds a `switch_properties_id()` unit test (no network) covering the id/geometry-only and mixed cases — it asserts the fallback omits `properties` (NA) rather than producing `"id"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)